### PR TITLE
Moderniza interface e adiciona progresso

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Aplicação simples para gerenciamento de alunos em academias ou atendimentos particulares.
 Permite registrar alunos, controlar planos, pagamentos, progresso, dietas e treinos, além de exportar
-informações em PDF. A interface foi renovada e utiliza `tkinter` com `ttkbootstrap` no tema `minty`.
+informações em PDF. A interface foi renovada e utiliza `tkinter` com `ttkbootstrap` no tema `flatly`.
 
 ## Requisitos
 - Python 3.13 para Windows

--- a/src/db.py
+++ b/src/db.py
@@ -19,8 +19,11 @@ def init_db():
             """)
 
 def listar_alunos():
+    """Retorna id, nome e progresso de todos os alunos."""
     with closing(sqlite3.connect(DB_NAME)) as conn:
-        cur = conn.execute("SELECT id, nome FROM alunos ORDER BY nome")
+        cur = conn.execute(
+            "SELECT id, nome, progresso FROM alunos ORDER BY nome"
+        )
         return cur.fetchall()
 
 def obter_aluno(aluno_id: int):


### PR DESCRIPTION
## Summary
- moderniza UI com tema `flatly`
- lista alunos mostrando progresso
- abre detalhes com duplo clique e remove botao de detalhes
- adiciona barra de progresso editavel
- documentacao atualizada

## Testing
- `python3 -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6854937dcd9c832c93e1385bc1a1a70e