### PR TITLE
Implement student card and improved PDF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Aplicação simples para gerenciamento de alunos em academias ou atendimentos particulares.
 Permite registrar alunos, controlar planos, pagamentos, progresso, dietas e treinos, além de exportar
 informações em PDF. A interface foi renovada e utiliza `tkinter` com `ttkbootstrap` no tema `flatly`.
+Agora um **card do aluno** exibe os dados resumidos do selecionado na lista, e os PDFs
+gerados recebem o nome do aluno e o tipo (treino ou dieta).
 
 ## Requisitos
 - Python 3.13 para Windows

--- a/src/pdf_utils.py
+++ b/src/pdf_utils.py
@@ -1,9 +1,18 @@
 from fpdf import FPDF
+import unicodedata
+
+
+def sanitize_filename(nome: str) -> str:
+    """Gera um nome de arquivo seguro removendo acentos e espacos."""
+    nfkd = unicodedata.normalize("NFKD", nome)
+    ascii_only = nfkd.encode("ASCII", "ignore").decode("ASCII")
+    return "".join(c if c.isalnum() else "_" for c in ascii_only).lower()
 
 
 def gerar_pdf(titulo: str, conteudo: str, caminho: str):
     pdf = FPDF()
     pdf.add_page()
+    pdf.set_title(titulo)
     pdf.set_font("Arial", size=12)
     pdf.cell(200, 10, txt=titulo, ln=True, align='C')
     pdf.multi_cell(0, 10, txt=conteudo)


### PR DESCRIPTION
## Summary
- show a student card on the main screen with name and progress
- name exported PDFs using the student's name and type (treino/dieta)
- add filename sanitization and PDF metadata
- document new functionality

## Testing
- `python -m py_compile src/*.py`
- `python src/main.py` *(fails: ModuleNotFoundError: No module named 'ttkbootstrap')*

------
https://chatgpt.com/codex/tasks/task_e_685494bf79e4832cb41129c1fffdeadf