### PR TITLE
Add training plan management

### DIFF
--- a/src/gui2.py
+++ b/src/gui2.py
@@ -6,6 +6,75 @@ import ttkbootstrap as tb
 
 import db
 
+
+class ExercicioRow(ttk.Frame):
+    def __init__(self, master, remover):
+        super().__init__(master)
+        self.vars = {
+            'nome': tk.StringVar(),
+            'series': tk.StringVar(),
+            'reps': tk.StringVar(),
+            'descanso': tk.StringVar(),
+            'obs': tk.StringVar(),
+        }
+        ttk.Entry(self, textvariable=self.vars['nome'], width=15).grid(row=0, column=0, padx=2, pady=2)
+        ttk.Entry(self, textvariable=self.vars['series'], width=5).grid(row=0, column=1, padx=2)
+        ttk.Entry(self, textvariable=self.vars['reps'], width=5).grid(row=0, column=2, padx=2)
+        ttk.Entry(self, textvariable=self.vars['descanso'], width=8).grid(row=0, column=3, padx=2)
+        ttk.Entry(self, textvariable=self.vars['obs'], width=15).grid(row=0, column=4, padx=2)
+        ttk.Button(self, text="X", width=2, command=lambda: remover(self)).grid(row=0, column=5, padx=2)
+
+    def get_data(self):
+        return {k: v.get().strip() for k, v in self.vars.items()}
+
+
+class PlanoModal(tb.Toplevel):
+    def __init__(self, aluno_id, ao_salvar):
+        super().__init__()
+        self.title("Novo Plano de Treino")
+        self.geometry("600x400")
+        self.grab_set()
+        self.aluno_id = aluno_id
+        self.ao_salvar = ao_salvar
+        self.exercicios = []
+
+        nome_var = tk.StringVar()
+        ttk.Label(self, text="Nome do Plano:").pack(anchor="w", padx=5, pady=5)
+        ttk.Entry(self, textvariable=nome_var, width=40).pack(anchor="w", padx=5)
+
+        ttk.Label(self, text="Descrição (opcional):").pack(anchor="w", padx=5, pady=(10,0))
+        desc = tk.Text(self, height=3, width=50)
+        desc.pack(anchor="w", padx=5)
+
+        area = ttk.Frame(self)
+        area.pack(fill="both", expand=True, pady=10)
+
+        def remover_row(row):
+            row.destroy()
+            self.exercicios.remove(row)
+
+        def add_row():
+            row = ExercicioRow(area, remover_row)
+            row.pack(fill="x", pady=2, padx=5)
+            self.exercicios.append(row)
+
+        ttk.Button(self, text="Adicionar Exercício", command=add_row).pack(pady=5)
+        add_row()
+
+        def salvar():
+            nome = nome_var.get().strip()
+            if not nome:
+                messagebox.showwarning("Aviso", "Nome do plano obrigatório", parent=self)
+                return
+            descricao = desc.get("1.0", tk.END).strip()
+            dados = [r.get_data() for r in self.exercicios if r.get_data().get('nome')]
+            exercicios_json = json.dumps(dados, ensure_ascii=False)
+            db.adicionar_plano(self.aluno_id, nome, descricao, exercicios_json)
+            self.destroy()
+            self.ao_salvar()
+
+        ttk.Button(self, text="Salvar", command=salvar).pack(pady=5)
+
 CONFIG_FILE = "config.json"
 
 def load_theme():
@@ -48,14 +117,69 @@ def abrir_modal_adicionar(atualizar):
     ttk.Button(win, text="Salvar", command=salvar).grid(row=2, column=0, columnspan=2, pady=10)
 
 class DetalhesWindow(tb.Toplevel):
-    def __init__(self, dados):
+    def __init__(self, dados, atualizar_lista):
         super().__init__()
         self.title("Detalhes do Aluno")
+        self.aluno_id = dados[0]
+        self.atualizar_lista = atualizar_lista
         self.configure(padx=20, pady=20)
+
         ttk.Label(self, text=dados[1], font=("Segoe UI", 12, "bold")).pack(anchor="w")
         ttk.Label(self, text=dados[2] or "-").pack(anchor="w")
-        ttk.Label(self, text=f"Inicio: {dados[3]}").pack(anchor="w", pady=(0,10))
-        ttk.Button(self, text="Fechar", command=self.destroy).pack()
+        ttk.Label(self, text=f"Inicio: {dados[3]}").pack(anchor="w", pady=(0, 10))
+
+        botoes = ttk.Frame(self)
+        botoes.pack(fill="x", pady=5)
+        ttk.Button(botoes, text="Excluir Aluno", command=self.excluir_aluno).pack(side="right")
+
+        self.planos_frame = ttk.Labelframe(self, text="Planos de Treino")
+        self.planos_frame.pack(fill="both", expand=True, pady=10)
+
+        ttk.Button(self.planos_frame, text="Adicionar Plano", command=self.abrir_plano_modal).pack(pady=5)
+        self.listar_planos()
+
+        ttk.Button(self, text="Fechar", command=self.destroy).pack(pady=5)
+
+    def listar_planos(self):
+        for child in self.planos_frame.winfo_children():
+            if getattr(child, "is_card", False):
+                child.destroy()
+        planos = db.listar_planos(self.aluno_id)
+        for pid, nome, descricao, exercicios in planos:
+            card = ttk.Frame(self.planos_frame, padding=10, relief="ridge")
+            card.is_card = True
+            card.pack(fill="x", pady=5)
+            ttk.Label(card, text=nome, font=("Segoe UI", 10, "bold")).pack(anchor="w")
+            if descricao:
+                ttk.Label(card, text=descricao).pack(anchor="w")
+            try:
+                exs = json.loads(exercicios) if exercicios else []
+            except json.JSONDecodeError:
+                exs = []
+            for ex in exs:
+                info = f"{ex.get('nome','')} - {ex.get('series','')}x{ex.get('reps','')}"
+                if ex.get('descanso'):
+                    info += f" descanso {ex.get('descanso')}"
+                if ex.get('obs'):
+                    info += f" ({ex.get('obs')})"
+                ttk.Label(card, text=info).pack(anchor="w")
+            btns = ttk.Frame(card)
+            btns.pack(anchor="e", pady=(5,0))
+            ttk.Button(btns, text="Excluir", command=lambda i=pid: self.excluir_plano(i)).pack(side="right")
+
+    def abrir_plano_modal(self):
+        PlanoModal(self.aluno_id, self.listar_planos)
+
+    def excluir_plano(self, plano_id):
+        if messagebox.askyesno("Confirmar", "Excluir plano?", parent=self):
+            db.remover_plano(plano_id)
+            self.listar_planos()
+
+    def excluir_aluno(self):
+        if messagebox.askyesno("Confirmar", "Excluir aluno?", parent=self):
+            db.remover_aluno(self.aluno_id)
+            self.atualizar_lista()
+            self.destroy()
 
 def criar_interface():
     db.init_db()
@@ -98,7 +222,7 @@ def criar_interface():
 
     def abrir_detalhes(aluno_id):
         dados = db.obter_aluno(aluno_id)
-        DetalhesWindow(dados)
+        DetalhesWindow(dados, atualizar_cards)
 
     def atualizar_cards():
         for child in cards.winfo_children():


### PR DESCRIPTION
## Summary
- create database table for treino plans
- add DB helpers for plans
- implement exercicio rows, plan modal and plan listing
- allow deleting alunos and planos

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python src/main.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6854a71c30c8832cbde3ef2a91cf34a2