### PR TITLE
Implement editing of workout plans

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -107,6 +107,16 @@ def adicionar_plano(aluno_id: int, nome: str, descricao: str, exercicios_json: s
             return cur.lastrowid
 
 
+def atualizar_plano(plano_id: int, nome: str, descricao: str, exercicios_json: str):
+    """Atualiza os dados de um plano de treino existente."""
+    with closing(sqlite3.connect(DB_NAME)) as conn:
+        with conn:
+            conn.execute(
+                "UPDATE planos SET nome=?, descricao=?, exercicios=? WHERE id=?",
+                (nome, descricao, exercicios_json, plano_id),
+            )
+
+
 def remover_plano(plano_id: int):
     with closing(sqlite3.connect(DB_NAME)) as conn:
         with conn:


### PR DESCRIPTION
## Summary
- allow editing of workout plans
- preserve IDs of exercises when editing
- update DB with new `atualizar_plano` method
- add edit button in student details window

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/main.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6854aab9bc6c832cb2185aab84891d31