### PR TITLE
Improve training details in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Aplicação simples para gerenciamento de alunos em academias ou atendimentos pa
 Permite registrar alunos, controlar planos, pagamentos, progresso, dietas e treinos, além de exportar
 informações em PDF. A interface usa `tkinter` com `ttkbootstrap` e agora conta com alternância de tema
 (claro ou escuro) e exibe os alunos em cartões. Os detalhes de cada aluno são
-mostrados na própria janela principal e os PDFs
+mostrados na própria janela principal e os PDFs.
+
+O módulo de treinos foi ampliado para aceitar detalhes de cada exercício, como séries, repetições,
+peso, tempo de descanso e observações. Cada plano pode ser exportado em PDF mostrando essas
+informações de forma estruturada.
 
 ## Requisitos
 - Python 3.11 ou superior

--- a/guia_instalacao.txt
+++ b/guia_instalacao.txt
@@ -23,10 +23,10 @@ Passo a passo para instalar o Gestor de Alunos
 5. **Usar o sistema**
    - Clique em "Adicionar" para registrar um novo aluno.
    - Dê duplo clique no nome ou utilize o botão "Detalhes" para abrir a ficha
-     do aluno em uma nova janela, onde é possível editar plano, pagamento,
-     progresso, dieta e treino.
-   - Os botões "Treino PDF" e "Dieta PDF" exportam os textos para arquivos PDF
-     na mesma pasta.
+     do aluno em uma nova janela. Lá é possível criar planos de treino com
+     exercício, séries, repetições, peso, descanso e observações.
+   - Cada plano possui opção para exportar um PDF resumindo todos os
+     exercícios. Também é possível exportar a dieta em PDF na mesma pasta.
 
 Todo o banco de dados é salvo no arquivo `alunos.db` e não necessita de conexão
 com a internet.

--- a/src/pdf_utils.py
+++ b/src/pdf_utils.py
@@ -17,3 +17,22 @@ def gerar_pdf(titulo: str, conteudo: str, caminho: str):
     pdf.cell(200, 10, txt=titulo, ln=True, align='C')
     pdf.multi_cell(0, 10, txt=conteudo)
     pdf.output(caminho)
+
+
+def gerar_treino_pdf(titulo: str, exercicios: list[dict], caminho: str):
+    """Gera um PDF estruturado com a lista de exercicios do plano."""
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_title(titulo)
+    pdf.set_font("Arial", size=12)
+    pdf.cell(200, 10, txt=titulo, ln=True, align="C")
+    for ex in exercicios:
+        linha = f"{ex.get('nome', '')} - {ex.get('series', '')}x{ex.get('reps', '')}"
+        if ex.get("peso"):
+            linha += f" {ex['peso']}"
+        if ex.get("descanso"):
+            linha += f" descanso {ex['descanso']}"
+        if ex.get("obs"):
+            linha += f" ({ex['obs']})"
+        pdf.multi_cell(0, 10, txt=linha)
+    pdf.output(caminho)


### PR DESCRIPTION
## Summary
- support weight information per exercise
- add headers and layout tweaks in training plan dialog
- allow exporting each plan as a PDF
- document enhanced training features

## Testing
- `pip check`
- `python -m py_compile src/db.py src/gui.py src/gui2.py src/main.py src/pdf_utils.py`
- `python src/main.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6854b0582cd8832c93ce795c0999a839