### PR TITLE
Fix load_theme exception handling

### DIFF
--- a/src/gui2.py
+++ b/src/gui2.py
@@ -119,8 +119,8 @@ def load_theme():
             with open(CONFIG_FILE, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 return data.get("theme", "superhero")
-        except Exception:
-            pass
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Erro ao carregar o tema: {e}")
     return "superhero"
 
 def save_theme(theme: str):


### PR DESCRIPTION
## Summary
- tighten exception handling when loading theme config
- log parsing errors

## Testing
- `python -m py_compile src/gui2.py`

------
https://chatgpt.com/codex/tasks/task_e_6854b4626cac832c8476e62d94565528