### PR TITLE
Add pytest configuration and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ informações de forma estruturada.
 1. Instale o Python 3.11 ou superior em seu computador.
 2. (Opcional) Crie um ambiente virtual com `python -m venv venv` e ative-o.
 3. Instale as dependências com `pip install -r requirements.txt`.
-4. Execute `python src/main.py` para abrir o sistema.
+4. (Opcional) Rode os testes com `pytest` para garantir que tudo está funcionando.
+5. Execute `python src/main.py` para abrir o sistema.
 
 Todo o banco de dados fica salvo localmente em `alunos.db`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ttkbootstrap>=1.13
 fpdf>=1.7
 pillow>=10
+pytest>=7

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import db
+
+
+def test_add_and_get_aluno(tmp_path):
+    db.DB_NAME = str(tmp_path / "test.db")
+    db.init_db()
+    aluno_id = db.adicionar_aluno("Maria", "maria@test.com")
+    aluno = db.obter_aluno(aluno_id)
+    assert aluno[1] == "Maria"
+    assert aluno[2] == "maria@test.com"
+    todos = db.listar_alunos()
+    assert any(a[0] == aluno_id for a in todos)
+
+
+def test_planos(tmp_path):
+    db.DB_NAME = str(tmp_path / "test.db")
+    db.init_db()
+    aluno_id = db.adicionar_aluno("Jose", "jose@test.com")
+    plano_id = db.adicionar_plano(aluno_id, "Treino A", "descricao", "[]")
+    planos = db.listar_planos(aluno_id)
+    assert len(planos) == 1
+    assert planos[0][0] == plano_id

--- a/tests/test_pdf_utils.py
+++ b/tests/test_pdf_utils.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import pdf_utils
+
+
+def test_sanitize_filename():
+    nome = "João da Silva 1/2"
+    assert pdf_utils.sanitize_filename(nome) == "joao_da_silva_1_2"
+
+
+def test_gerar_pdf(tmp_path):
+    caminho = tmp_path / "out.pdf"
+    pdf_utils.gerar_pdf("Titulo", "Conteudo", str(caminho))
+    assert caminho.exists()
+    assert caminho.stat().st_size > 0
+
+
+def test_gerar_treino_pdf(tmp_path):
+    caminho = tmp_path / "treino.pdf"
+    exercicios = [{"nome": "Supino", "series": "3", "reps": "10", "peso": "20kg"}]
+    pdf_utils.gerar_treino_pdf("Treino", exercicios, str(caminho))
+    assert caminho.exists()
+    assert caminho.stat().st_size > 0


### PR DESCRIPTION
## Summary
- configure test step in README
- add pytest requirement
- implement basic unit tests for `db.py` and `pdf_utils.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b463eca0832c926a6ac47b04d31d