### PR TITLE
Fix Portuguese spelling in GUI warning

### DIFF
--- a/src/gui2.py
+++ b/src/gui2.py
@@ -144,7 +144,7 @@ def abrir_modal_adicionar(atualizar):
         nome = nome_var.get().strip()
         email = email_var.get().strip()
         if not nome:
-            messagebox.showwarning("Aviso", "Nome nao pode ser vazio", parent=win)
+            messagebox.showwarning("Aviso", "Nome não pode ser vazio", parent=win)
             return
         db.adicionar_aluno(nome, email)
         win.destroy()


### PR DESCRIPTION
## Summary
- correct spelling of "não" in GUI warning message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b7c6a394832c8116ed35279affe5