### PR TITLE
Improve modal grid behavior

### DIFF
--- a/src/gui2.py
+++ b/src/gui2.py
@@ -131,14 +131,15 @@ def abrir_modal_adicionar(atualizar):
     win = tb.Toplevel()
     win.title("Adicionar Aluno")
     win.grab_set()
+    win.grid_columnconfigure(1, weight=1)
 
     nome_var = tk.StringVar()
     email_var = tk.StringVar()
 
     ttk.Label(win, text="Nome:").grid(row=0, column=0, padx=5, pady=5, sticky="e")
-    ttk.Entry(win, textvariable=nome_var, width=30).grid(row=0, column=1, padx=5, pady=5)
+    ttk.Entry(win, textvariable=nome_var, width=30).grid(row=0, column=1, padx=5, pady=5, sticky="ew")
     ttk.Label(win, text="Email:").grid(row=1, column=0, padx=5, pady=5, sticky="e")
-    ttk.Entry(win, textvariable=email_var, width=30).grid(row=1, column=1, padx=5, pady=5)
+    ttk.Entry(win, textvariable=email_var, width=30).grid(row=1, column=1, padx=5, pady=5, sticky="ew")
 
     def salvar():
         nome = nome_var.get().strip()


### PR DESCRIPTION
## Summary
- add column weight to new student modal so entries expand
- let entry fields stretch with the window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b7ca72c4832c9267e482d584c98b