### PR TITLE
Fix accent on GUI label

### DIFF
--- a/src/gui2.py
+++ b/src/gui2.py
@@ -163,7 +163,7 @@ class DetalhesFrame(ttk.Frame):
         ttk.Button(self, text="Voltar", command=self.voltar).pack(anchor="w")
         ttk.Label(self, text=dados[1], font=("Segoe UI", 12, "bold")).pack(anchor="w")
         ttk.Label(self, text=dados[2] or "-").pack(anchor="w")
-        ttk.Label(self, text=f"Inicio: {dados[3]}").pack(anchor="w", pady=(0, 10))
+        ttk.Label(self, text=f"Início: {dados[3]}").pack(anchor="w", pady=(0, 10))
 
         botoes = ttk.Frame(self)
         botoes.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- fix 'Inicio' label accent in `src/gui2.py`

## Testing
- `pytest -q`
- `python src/gui2.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6854b7c86d2c832c9d678e2fe48d2117