### PR TITLE
Fix plan button placement

### DIFF
--- a/src/gui2.py
+++ b/src/gui2.py
@@ -172,8 +172,8 @@ class DetalhesFrame(ttk.Frame):
         self.planos_frame = ttk.Labelframe(self, text="Planos de Treino")
         self.planos_frame.pack(fill="both", expand=True, pady=10)
 
-        ttk.Button(self.planos_frame, text="Adicionar Plano", command=self.abrir_plano_modal).pack(pady=5)
         self.listar_planos()
+        ttk.Button(self.planos_frame, text="Adicionar Plano", command=self.abrir_plano_modal).pack(pady=5)
 
     def listar_planos(self):
         for child in self.planos_frame.winfo_children():


### PR DESCRIPTION
## Summary
- move the "Adicionar Plano" button to appear after plan listing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b7c9cb34832ca7435d749fb9d980