### PR TITLE
Organize theme config and add GUI feedback

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+CONFIG_FILE = "config.json"
+
+
+def load_theme() -> str:
+    """Return the saved theme name or a default."""
+    if os.path.exists(CONFIG_FILE):
+        try:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                return data.get("theme", "superhero")
+        except (json.JSONDecodeError, OSError):
+            pass
+    return "superhero"
+
+
+def save_theme(theme: str) -> None:
+    """Persist the selected theme."""
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump({"theme": theme}, f)


### PR DESCRIPTION
## Summary
- extract theme load/save into new `config_manager` module
- show status dialogs when adding or deleting records
- display a progress bar when generating PDF
- document `criar_interface`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854be2a71d4832cad87d3a34b66fcd1