### PR TITLE
Refatoração para separar responsabilidades

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,3 +1,5 @@
+"""Gerencia configurações simples da aplicação."""
+
 import json
 import os
 
@@ -20,3 +22,4 @@ def save_theme(theme: str) -> None:
     """Persist the selected theme."""
     with open(CONFIG_FILE, "w", encoding="utf-8") as f:
         json.dump({"theme": theme}, f)
+

--- a/src/db.py
+++ b/src/db.py
@@ -1,12 +1,15 @@
+"""Camada de acesso a dados utilizando SQLite."""
+
 import sqlite3
 from contextlib import closing
+from typing import Iterable, Optional
 
 DB_NAME = "alunos.db"
 
 # Allowed columns that can be updated via ``atualizar_aluno``. This helps avoid
 # SQL injection by validating user provided column names before composing the
 # query string.
-VALID_UPDATE_FIELDS = {
+VALID_UPDATE_FIELDS: set[str] = {
     "nome",
     "email",
     "data_inicio",
@@ -17,7 +20,8 @@ VALID_UPDATE_FIELDS = {
     "treino",
 }
 
-def init_db():
+def init_db() -> None:
+    """Cria as tabelas principais se ainda não existirem."""
     with closing(sqlite3.connect(DB_NAME)) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
         with conn:
@@ -59,15 +63,15 @@ def init_db():
             except sqlite3.OperationalError:
                 pass
 
-def listar_alunos():
-    """Retorna informacoes basicas de todos os alunos."""
+def listar_alunos() -> list[tuple]:
+    """Retorna informações básicas de todos os alunos."""
     with closing(sqlite3.connect(DB_NAME)) as conn:
         cur = conn.execute(
             "SELECT id, nome, email, data_inicio FROM alunos ORDER BY nome"
         )
         return cur.fetchall()
 
-def obter_aluno(aluno_id: int):
+def obter_aluno(aluno_id: int) -> Optional[tuple]:
     with closing(sqlite3.connect(DB_NAME)) as conn:
         cur = conn.execute(
             "SELECT id, nome, email, data_inicio, plano, pagamento, progresso, dieta, treino FROM alunos WHERE id=?",
@@ -75,8 +79,8 @@ def obter_aluno(aluno_id: int):
         )
         return cur.fetchone()
 
-def adicionar_aluno(nome: str, email: str):
-    """Insere um novo aluno com a data atual."""
+def adicionar_aluno(nome: str, email: str) -> int:
+    """Insere um novo aluno com a data atual e retorna o ID gerado."""
     from datetime import datetime
 
     data_inicio = datetime.now().strftime("%Y-%m-%d")
@@ -88,7 +92,7 @@ def adicionar_aluno(nome: str, email: str):
             )
             return cur.lastrowid
 
-def atualizar_aluno(aluno_id: int, campo: str, valor: str):
+def atualizar_aluno(aluno_id: int, campo: str, valor: str) -> None:
     """Update a single column of an existing aluno.
 
     Parameters
@@ -113,14 +117,14 @@ def atualizar_aluno(aluno_id: int, campo: str, valor: str):
                 (valor, aluno_id),
             )
 
-def remover_aluno(aluno_id: int):
+def remover_aluno(aluno_id: int) -> None:
     with closing(sqlite3.connect(DB_NAME)) as conn:
         with conn:
             conn.execute("DELETE FROM alunos WHERE id=?", (aluno_id,))
 
 # ----- Planos de treino -----
 
-def listar_planos(aluno_id: int):
+def listar_planos(aluno_id: int) -> list[tuple]:
     """Retorna todos os planos de treino de um aluno."""
     with closing(sqlite3.connect(DB_NAME)) as conn:
         cur = conn.execute(
@@ -130,7 +134,7 @@ def listar_planos(aluno_id: int):
         return cur.fetchall()
 
 
-def adicionar_plano(aluno_id: int, nome: str, descricao: str, exercicios_json: str):
+def adicionar_plano(aluno_id: int, nome: str, descricao: str, exercicios_json: str) -> int:
     """Adiciona um novo plano de treino."""
     with closing(sqlite3.connect(DB_NAME)) as conn:
         with conn:
@@ -141,7 +145,7 @@ def adicionar_plano(aluno_id: int, nome: str, descricao: str, exercicios_json: s
             return cur.lastrowid
 
 
-def atualizar_plano(plano_id: int, nome: str, descricao: str, exercicios_json: str):
+def atualizar_plano(plano_id: int, nome: str, descricao: str, exercicios_json: str) -> None:
     """Atualiza os dados de um plano de treino existente."""
     with closing(sqlite3.connect(DB_NAME)) as conn:
         with conn:
@@ -151,7 +155,8 @@ def atualizar_plano(plano_id: int, nome: str, descricao: str, exercicios_json: s
             )
 
 
-def remover_plano(plano_id: int):
+def remover_plano(plano_id: int) -> None:
     with closing(sqlite3.connect(DB_NAME)) as conn:
         with conn:
             conn.execute("DELETE FROM planos WHERE id=?", (plano_id,))
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-from gui2 import criar_interface
+from gui import criar_interface
 
 if __name__ == "__main__":
     criar_interface()

--- a/src/pdf_utils.py
+++ b/src/pdf_utils.py
@@ -1,3 +1,5 @@
+"""Funções auxiliares para geração de relatórios em PDF."""
+
 from fpdf import FPDF
 import unicodedata
 
@@ -9,7 +11,8 @@ def sanitize_filename(nome: str) -> str:
     return "".join(c if c.isalnum() else "_" for c in ascii_only).lower()
 
 
-def gerar_pdf(titulo: str, conteudo: str, caminho: str):
+def gerar_pdf(titulo: str, conteudo: str, caminho: str) -> None:
+    """Gera um PDF simples com título e conteúdo livre."""
     pdf = FPDF()
     pdf.add_page()
     pdf.set_title(titulo)
@@ -19,8 +22,8 @@ def gerar_pdf(titulo: str, conteudo: str, caminho: str):
     pdf.output(caminho)
 
 
-def gerar_treino_pdf(titulo: str, exercicios: list[dict], caminho: str):
-    """Gera um PDF estruturado com a lista de exercicios do plano."""
+def gerar_treino_pdf(titulo: str, exercicios: list[dict], caminho: str) -> None:
+    """Gera um PDF estruturado com a lista de exercícios do plano."""
     pdf = FPDF()
     pdf.add_page()
     pdf.set_title(titulo)
@@ -36,3 +39,4 @@ def gerar_treino_pdf(titulo: str, exercicios: list[dict], caminho: str):
             linha += f" ({ex['obs']})"
         pdf.multi_cell(0, 10, txt=linha)
     pdf.output(caminho)
+

--- a/src/widgets.py
+++ b/src/widgets.py
@@ -1,0 +1,114 @@
+"""Componentes visuais reutilizáveis para a aplicação."""
+
+import json
+import tkinter as tk
+from tkinter import ttk, messagebox
+from typing import Callable, Optional
+import ttkbootstrap as tb
+
+
+class ExercicioRow(ttk.Frame):
+    """Linha de entrada para um exercício do plano."""
+
+    def __init__(self, master: tk.Widget, remover: Callable[["ExercicioRow"], None], dados: Optional[dict] = None) -> None:
+        super().__init__(master)
+        self.ex_id: Optional[int] = None
+        self.vars = {
+            "nome": tk.StringVar(),
+            "series": tk.StringVar(),
+            "reps": tk.StringVar(),
+            "peso": tk.StringVar(),
+            "descanso": tk.StringVar(),
+            "obs": tk.StringVar(),
+        }
+        if dados:
+            self.ex_id = dados.get("id")
+            for k in self.vars:
+                self.vars[k].set(dados.get(k, ""))
+        ttk.Entry(self, textvariable=self.vars["nome"], width=15).grid(row=0, column=0, padx=2, pady=2)
+        ttk.Entry(self, textvariable=self.vars["series"], width=5).grid(row=0, column=1, padx=2)
+        ttk.Entry(self, textvariable=self.vars["reps"], width=5).grid(row=0, column=2, padx=2)
+        ttk.Entry(self, textvariable=self.vars["peso"], width=7).grid(row=0, column=3, padx=2)
+        ttk.Entry(self, textvariable=self.vars["descanso"], width=8).grid(row=0, column=4, padx=2)
+        ttk.Entry(self, textvariable=self.vars["obs"], width=15).grid(row=0, column=5, padx=2)
+        ttk.Button(self, text="X", width=2, command=lambda: remover(self)).grid(row=0, column=6, padx=2)
+
+    def get_data(self) -> dict:
+        """Retorna os dados preenchidos."""
+        data = {k: v.get().strip() for k, v in self.vars.items()}
+        if self.ex_id is not None:
+            data["id"] = self.ex_id
+        return data
+
+
+class PlanoModal(tb.Toplevel):
+    """Janela para criação ou edição de planos de treino."""
+
+    def __init__(self, aluno_id: int, salvar: Callable[[int, str, str, str, Optional[int]], None], plano: Optional[dict] = None) -> None:
+        super().__init__()
+        self.geometry("650x450")
+        self.grab_set()
+        self.aluno_id = aluno_id
+        self.salvar = salvar
+        self.exercicios: list[ExercicioRow] = []
+        self.plano_id: Optional[int] = None
+
+        nome_var = tk.StringVar()
+        self.title("Novo Plano de Treino" if plano is None else "Editar Plano de Treino")
+        ttk.Label(self, text="Nome do Plano:").pack(anchor="w", padx=5, pady=5)
+        ttk.Entry(self, textvariable=nome_var, width=40).pack(anchor="w", padx=5)
+
+        ttk.Label(self, text="Descrição (opcional):").pack(anchor="w", padx=5, pady=(10, 0))
+        desc = tk.Text(self, height=3, width=50)
+        desc.pack(anchor="w", padx=5)
+
+        area = ttk.Frame(self)
+        area.pack(fill="both", expand=True, pady=10)
+
+        header = ttk.Frame(area)
+        header.pack(fill="x")
+        cols = ["Exercício", "Séries", "Reps", "Peso", "Descanso", "Obs"]
+        for i, t in enumerate(cols):
+            ttk.Label(header, text=t, font=("Segoe UI", 9, "bold")).grid(row=0, column=i, padx=2)
+
+        def remover_row(row: ExercicioRow) -> None:
+            row.destroy()
+            self.exercicios.remove(row)
+
+        def add_row(dados: Optional[dict] = None) -> None:
+            row = ExercicioRow(area, remover_row, dados)
+            row.pack(fill="x", pady=2, padx=5)
+            self.exercicios.append(row)
+
+        ttk.Button(self, text="Adicionar Exercício", command=lambda: add_row()).pack(pady=5)
+
+        if plano:
+            self.plano_id = plano.get("id")
+            nome_var.set(plano.get("nome", ""))
+            desc.insert("1.0", plano.get("descricao", "") or "")
+            try:
+                exs = json.loads(plano.get("exercicios") or "[]")
+            except json.JSONDecodeError:
+                exs = []
+            if exs:
+                for ex in exs:
+                    add_row(ex)
+            else:
+                add_row()
+        else:
+            add_row()
+
+        def salvar_click() -> None:
+            nome = nome_var.get().strip()
+            if not nome:
+                messagebox.showwarning("Aviso", "Nome do plano obrigatório", parent=self)
+                return
+            descricao = desc.get("1.0", tk.END).strip()
+            dados = [r.get_data() for r in self.exercicios if r.get_data().get("nome")]
+            exercicios_json = json.dumps(dados, ensure_ascii=False)
+            self.salvar(self.aluno_id, nome, descricao, exercicios_json, self.plano_id)
+            self.destroy()
+
+        ttk.Button(self, text="Salvar", command=salvar_click).pack(pady=5)
+
+


### PR DESCRIPTION
## Summary
- modularize interface by splitting widgets and gui code
- add type hints and short docstrings across modules
- rename `gui2.py` to `gui.py` and update main entry

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cafc9570832ca25294fa333e9427