### PR TITLE
Improve UI responsiveness with background tasks

### DIFF
--- a/src/background.py
+++ b/src/background.py
@@ -1,0 +1,24 @@
+import threading
+import tkinter as tk
+from typing import Callable, Any, Optional
+
+
+def run_task(
+    widget: tk.Widget,
+    func: Callable[[], Any],
+    on_success: Optional[Callable[[Any], None]] = None,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> None:
+    """Execute ``func`` in a background thread and invoke callbacks on the main thread."""
+
+    def wrapper() -> None:
+        try:
+            result = func()
+        except Exception as exc:  # noqa: BLE001
+            if on_error:
+                widget.after(0, on_error, exc)
+        else:
+            if on_success:
+                widget.after(0, on_success, result)
+
+    threading.Thread(target=wrapper, daemon=True).start()


### PR DESCRIPTION
## Summary
- add a `background` module to run tasks in a thread and update the UI via callbacks
- use `run_task` in GUI operations that interact with the database or generate PDFs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854df20f8f4832cbafa2811d6f50e81