### PR TITLE
Fix packaging and test setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,5 @@ py-modules = [
 ]
 
 [tool.setuptools.data-files]
-"" = ["config.json"]
+"" = ["src/config.json"]
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -7,12 +7,15 @@ import tkinter as tk
 from unittest import mock
 import pytest
 from pyvirtualdisplay import Display
+import shutil
 
 import gui
 
 
 @pytest.fixture(scope="module", autouse=True)
 def _display():
+    if shutil.which("Xvfb") is None:
+        pytest.skip("Xvfb not available")
     disp = Display(visible=0, size=(800, 600))
     disp.start()
     yield


### PR DESCRIPTION
## Summary
- include `src/config.json` when building package
- skip GUI tests when Xvfb is unavailable

## Testing
- `pip install -q .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e2db33dc832c978cbb03735d5905