### PR TITLE
Fix database location

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ informações de forma estruturada.
 4. (Opcional) Rode os testes com `pip install .[test]` e em seguida `pytest`.
 5. Após a instalação, rode `gestor-alunos` para abrir o sistema.
 
-Todo o banco de dados fica salvo localmente em `alunos.db`.
+O banco de dados agora fica salvo em `~/.gestor_alunos/alunos.db`,
+garantindo que os dados permaneçam mesmo ao executar o programa
+em diretórios diferentes.
 
 ## Licença
 

--- a/src/db.py
+++ b/src/db.py
@@ -2,9 +2,12 @@
 
 import sqlite3
 from contextlib import closing
+from pathlib import Path
 from typing import Iterable, Optional
 
-DB_NAME = "alunos.db"
+DB_DIR = Path.home() / ".gestor_alunos"
+DB_DIR.mkdir(parents=True, exist_ok=True)
+DB_NAME = str(DB_DIR / "alunos.db")
 
 # Allowed columns that can be updated via ``atualizar_aluno``. This helps avoid
 # SQL injection by validating user provided column names before composing the


### PR DESCRIPTION
## Summary
- store database in `~/.gestor_alunos` to keep data between runs
- document new path in README

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857310dad48832c95f3cff99eb6982d