### PR TITLE
Add installer scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,7 @@ healthchecksdb
 
 # Ignore Windows executables
 *.exe
+
+# PyInstaller artifacts
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -29,3 +29,20 @@ em diretórios diferentes.
 
 Distribuído sob a licença MIT. Consulte o arquivo [LICENSE](LICENSE) para mais
 informações.
+
+## Gerar executável e instalador
+
+Para distribuir o programa como aplicativo de desktop, você pode gerar um
+executável único e um instalador simples. Siga estes passos:
+
+1. Instale o PyInstaller com `pip install pyinstaller`.
+2. Execute o script `scripts/build_exe.ps1` no PowerShell para criar o
+   executável em `dist/gestor-alunos.exe`.
+3. Opcionalmente, utilize o script `installer/installer.iss` com o Inno Setup
+   para montar um instalador. Esse instalador inclui o executável e rodará o
+   script `setup_data.ps1` na primeira execução, baixando os dados mais recentes
+   do repositório.
+
+O script `scripts/setup_data.ps1` faz o download ou atualização do conteúdo do
+repositório via `git`, garantindo que o usuário receba os arquivos atuais ao
+instalar o aplicativo.

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -1,0 +1,13 @@
+; Script de exemplo do Inno Setup para o Gestor de Alunos
+[Setup]
+AppName=Gestor de Alunos
+AppVersion=0.1.0
+DefaultDirName={pf}\GestorAlunos
+OutputBaseFilename=GestorAlunosSetup
+
+[Files]
+Source: "dist\gestor-alunos.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "scripts\setup_data.ps1"; DestDir: "{app}"; Flags: ignoreversion
+
+[Run]
+Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File \"{app}\setup_data.ps1\""; Flags: runhidden

--- a/scripts/build_exe.ps1
+++ b/scripts/build_exe.ps1
@@ -1,0 +1,7 @@
+# Gera o executável do Gestor de Alunos usando PyInstaller
+param(
+    [string]$Entry = "src/main.py",
+    [string]$Name = "gestor-alunos"
+)
+
+python -m PyInstaller --onefile --name $Name $Entry

--- a/scripts/setup_data.ps1
+++ b/scripts/setup_data.ps1
@@ -1,0 +1,10 @@
+param(
+    [string]$Destination = "$PSScriptRoot\dados",
+    [string]$RepoUrl = "https://github.com/usuario/I.A-Sarah.git"
+)
+
+if (Test-Path $Destination) {
+    git -C $Destination pull
+} else {
+    git clone $RepoUrl $Destination
+}


### PR DESCRIPTION
## Summary
- add scripts to build executable and fetch data from GitHub
- provide example Inno Setup script for Windows installer
- document how to generate the executable and installer
- ignore PyInstaller build folders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685736a8e624832cbcdb0d47e640f2ff