### PR TITLE
Fix relative paths in installer

### DIFF
--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -6,8 +6,8 @@ DefaultDirName={pf}\GestorAlunos
 OutputBaseFilename=GestorAlunosSetup
 
 [Files]
-Source: "dist\gestor-alunos.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "scripts\setup_data.ps1"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\gestor-alunos.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\scripts\setup_data.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Run]
 Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File \"{app}\setup_data.ps1\""; Flags: runhidden


### PR DESCRIPTION
## Summary
- fix relative paths in Inno Setup script so it can find the files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573bce8524832ca8099e240e9a23b2