### PR TITLE
Add Inno Setup build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ executável único e um instalador simples. Siga estes passos:
    para montar um instalador. Esse instalador inclui o executável e rodará o
    script `setup_data.ps1` na primeira execução, baixando os dados mais recentes
    do repositório.
+4. Execute `installer\build_installer.ps1` para gerar o instalador configurado para `C:\Users\jhona\Documents\GitHub\I.A-Sarah`.
 
 O script `scripts/setup_data.ps1` faz o download ou atualização do conteúdo do
 repositório via `git`, garantindo que o usuário receba os arquivos atuais ao

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -1,0 +1,9 @@
+# Compila o instalador do Gestor de Alunos usando o Inno Setup
+
+# Caminho do repositório
+$repo = "C:\Users\jhona\Documents\GitHub\I.A-Sarah"
+
+# Caminho do executável do Inno Setup (ajuste se estiver instalado em outro lugar)
+$inno = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+
+& $inno "$repo\installer\installer.iss" /DSourceRoot="$repo"

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -1,4 +1,10 @@
 ; Script de exemplo do Inno Setup para o Gestor de Alunos
+
+; Caminho padrao do projeto. Pode ser sobrescrito ao compilar com /DSourceRoot=...
+#ifndef SourceRoot
+#define SourceRoot "C:\\Users\\jhona\\Documents\\GitHub\\I.A-Sarah"
+#endif
+
 [Setup]
 AppName=Gestor de Alunos
 AppVersion=0.1.0
@@ -6,8 +12,8 @@ DefaultDirName={pf}\GestorAlunos
 OutputBaseFilename=GestorAlunosSetup
 
 [Files]
-Source: "..\dist\gestor-alunos.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\scripts\setup_data.ps1"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceRoot}\dist\gestor-alunos.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceRoot}\scripts\setup_data.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Run]
 Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File \"{app}\setup_data.ps1\""; Flags: runhidden


### PR DESCRIPTION
## Summary
- provide PowerShell helper to compile installer with Inno Setup
- allow overriding source path in `installer.iss`
- document build script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574d478828832caf15046437c20ae9