### PR TITLE
Improve Inno Setup build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,14 @@ informações.
 ## Gerar executável e instalador
 
 Para distribuir o programa como aplicativo de desktop, você pode gerar um
-executável único e um instalador simples. Siga estes passos:
+executável único e um instalador para Windows.
 
-1. Instale o PyInstaller com `pip install pyinstaller`.
-2. Execute o script `scripts/build_exe.ps1` no PowerShell para criar o
-   executável em `dist/gestor-alunos.exe`.
-3. Opcionalmente, utilize o script `installer/installer.iss` com o Inno Setup
-   para montar um instalador. Esse instalador inclui o executável e rodará o
-   script `setup_data.ps1` na primeira execução, baixando os dados mais recentes
-   do repositório.
-4. Execute `installer\build_installer.ps1` para gerar o instalador apontando para o caminho onde o repositório está clonado.
+1. Instale o PyInstaller com `pip install pyinstaller` e tenha o Inno Setup
+   instalado em seu sistema.
+2. No PowerShell, execute `installer\build_installer.ps1`.
+   Esse script cria o executável com o PyInstaller e, em seguida, utiliza o
+   Inno Setup para gerar `GestorAlunosSetup.exe`. Caso o Inno Setup esteja em
+   outro diretório, ajuste o caminho no script.
 
 O script `scripts/setup_data.ps1` faz o download ou atualização do conteúdo do
 repositório via `git`, garantindo que o usuário receba os arquivos atuais ao

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -3,7 +3,11 @@
 # Caminho do repositório (este script está na pasta "installer")
 $repo = (Resolve-Path "$PSScriptRoot\..\").Path
 
+# Gera o executável com o PyInstaller
+& "$repo\scripts\build_exe.ps1"
+
 # Caminho do executável do Inno Setup (ajuste se estiver instalado em outro lugar)
 $inno = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 
+# Compila o instalador apontando para a raiz do repositório
 & $inno "$repo\installer\installer.iss" /DSourceRoot="$repo"

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -2,7 +2,7 @@
 
 ; Caminho padrao do projeto. Pode ser sobrescrito ao compilar com /DSourceRoot=...
 #ifndef SourceRoot
-#define SourceRoot "C:\\caminho\\para\\I.A-Sarah"  ; ajuste para o local do repositorio
+#define SourceRoot "C:\\caminho\\para\\I.A-Sarah"  ; valor padrao, substituido pelo script de build
 #endif
 
 [Setup]


### PR DESCRIPTION
## Summary
- build the EXE automatically before compiling the installer
- clarify installation instructions for creating the installer
- tweak comment in `installer.iss`

## Testing
- `pip install .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576c9403ec832ca9e2dc63c6efd7eb