### PR TITLE
Add Inno Setup path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ executável único e um instalador para Windows.
 2. No PowerShell, execute `installer\build_installer.ps1`.
    Esse script cria o executável com o PyInstaller e, em seguida, utiliza o
    Inno Setup para gerar `GestorAlunosSetup.exe`. Caso o Inno Setup esteja em
-   outro diretório, ajuste o caminho no script.
+   outro diretório, use o parâmetro opcional `-InnoPath` para informar o caminho
+   para `ISCC.exe`.
 
 O script `scripts/setup_data.ps1` faz o download ou atualização do conteúdo do
 repositório via `git`, garantindo que o usuário receba os arquivos atuais ao

--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -1,13 +1,20 @@
 # Compila o instalador do Gestor de Alunos usando o Inno Setup
 
+param(
+    [string]$InnoPath = "$Env:ProgramFiles\Inno Setup 6\ISCC.exe"
+)
+
 # Caminho do repositório (este script está na pasta "installer")
 $repo = (Resolve-Path "$PSScriptRoot\..\").Path
 
 # Gera o executável com o PyInstaller
 & "$repo\scripts\build_exe.ps1"
 
-# Caminho do executável do Inno Setup (ajuste se estiver instalado em outro lugar)
-$inno = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+# Caminho do executável do Inno Setup (pode ser ajustado pelo parâmetro)
+if (-not (Test-Path $InnoPath)) {
+    Write-Error "ISCC.exe não encontrado em $InnoPath"
+    exit 1
+}
 
 # Compila o instalador apontando para a raiz do repositório
-& $inno "$repo\installer\installer.iss" /DSourceRoot="$repo"
+& $InnoPath "$repo\installer\installer.iss" /DSourceRoot="$repo"


### PR DESCRIPTION
## Summary
- make `installer/build_installer.ps1` accept optional `InnoPath` parameter
- check `InnoPath` before running Inno Setup
- document optional parameter in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685779217a7c832cbe1a1a2113063884