### PR TITLE
Improve installer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ executável único e um instalador para Windows.
    Esse script cria o executável com o PyInstaller e, em seguida, utiliza o
    Inno Setup para gerar `GestorAlunosSetup.exe`. Caso o Inno Setup esteja em
    outro diretório, ajuste o caminho no script.
+   
+   Se preferir compilar o arquivo `installer.iss` manualmente, é necessário
+   informar o caminho para a raiz do repositório com
+   `/DSourceRoot=<caminho-do-repositório>`.
 
 O script `scripts/setup_data.ps1` faz o download ou atualização do conteúdo do
 repositório via `git`, garantindo que o usuário receba os arquivos atuais ao

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -1,8 +1,9 @@
 ; Script de exemplo do Inno Setup para o Gestor de Alunos
 
-; Caminho padrao do projeto. Pode ser sobrescrito ao compilar com /DSourceRoot=...
+; Defina a raiz do projeto ao compilar usando
+;   /DSourceRoot=<caminho do repositório>
+; Este parâmetro é obrigatório para localizar os arquivos
 #ifndef SourceRoot
-#define SourceRoot "C:\\caminho\\para\\I.A-Sarah"  ; valor padrao, substituido pelo script de build
 #endif
 
 [Setup]


### PR DESCRIPTION
## Summary
- clarify that `/DSourceRoot` must be given when compiling `installer.iss`
- remove fallback value in installer script
- document manual build flag in README

## Testing
- `pip install .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685779202ab0832c98eb730d03c30d9c