### PR TITLE
Add notes on PowerShell execution policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ executável único e um instalador para Windows.
    `Program Files (x86)` antes de gerar o executável com o PyInstaller e o
    instalador com o Inno Setup. Caso o Inno Setup esteja em outro local,
    informe o caminho completo usando o parâmetro opcional `-InnoPath`.
+3. Se o PowerShell bloquear a execução do script (políticas `Restricted` ou
+   `AllSigned`), execute-o com:
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File installer\build_installer.ps1
+   ```
+   ou defina a política para `RemoteSigned` com:
+   ```powershell
+   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+   ```
 
 O script `scripts/setup_data.ps1` faz o download ou atualização do conteúdo do
 repositório via `git`. Caso deseje utilizar um fork, informe a URL com o

--- a/guia_instalacao.txt
+++ b/guia_instalacao.txt
@@ -30,3 +30,9 @@ Passo a passo para instalar o Gestor de Alunos
 
 Todo o banco de dados é salvo no arquivo `alunos.db` e não necessita de conexão
 com a internet.
+
+Para criar um instalador do programa no Windows, execute o script
+`installer\build_installer.ps1`. Caso o PowerShell informe que a execução está
+bloqueada pelas políticas `Restricted` ou `AllSigned`, utilize:
+`powershell -ExecutionPolicy Bypass -File installer\build_installer.ps1` ou
+defina a política como `RemoteSigned` com `Set-ExecutionPolicy`.


### PR DESCRIPTION
## Summary
- warn that PowerShell may block `build_installer.ps1`
- show how to bypass execution policy or set `RemoteSigned`
- document the same note in `guia_instalacao.txt`

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577dae9560832c97c1bf188330dc3d