### PR TITLE
Fix Inno Setup parameters quoting

### DIFF
--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -16,4 +16,4 @@ Source: "{#SourceRoot}\dist\gestor-alunos.exe"; DestDir: "{app}"; Flags: ignorev
 Source: "{#SourceRoot}\scripts\setup_data.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Run]
-Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File \"{app}\setup_data.ps1\""; Flags: runhidden
+Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File \"\"{app}\\setup_data.ps1\"\""; Flags: runhidden


### PR DESCRIPTION
## Summary
- escape quotes in `installer.iss` so Inno Setup parses Parameters correctly

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685781536424832c99c0d10d14c3e466