### PR TITLE
Add FastAPI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ O banco de dados é salvo em `~/.gestor_alunos/alunos.db`.
    ```bash
    iasarah
    ```
+6. Para rodar a API FastAPI:
+   ```bash
+   iasarah-api
+   ```
 
 ### Testes
 Para executar os testes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ ttkbootstrap = "^1.13"
 fpdf = "^1.7"
 pillow = "^10"
 openpyxl = "^3.1"
+fastapi = "^0.110"
+uvicorn = "^0.29"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7"
@@ -21,6 +23,7 @@ pyvirtualdisplay = "^3"
 pytest-xdist = "^3.5"
 coverage = "^7.4"
 pytest-cov = "^4.1"
+httpx = "^0.27"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -33,6 +36,7 @@ pre-commit = "^3.5"
 
 [tool.poetry.scripts]
 iasarah = "ia_sarah.core.main:main"
+iasarah-api = "ia_sarah.core.interfaces.api.server:main"
 
 [tool.poetry.plugins."ia_sarah.exporters"]
 pdf = "ia_sarah.core.adapters.services.exporters:PDFExporter"

--- a/src/ia_sarah/core/interfaces/api/server.py
+++ b/src/ia_sarah/core/interfaces/api/server.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from ...use_cases import controllers
+
+app = FastAPI(title="I.A-Sarah API")
+
+
+class StudentIn(BaseModel):
+    nome: str
+    email: str
+
+
+@app.on_event("startup")
+def startup() -> None:
+    controllers.init_app()
+
+
+@app.get("/students")
+def list_students():
+    alunos = controllers.listar_alunos()
+    return [
+        {"id": a[0], "nome": a[1], "email": a[2], "data_inicio": a[3]} for a in alunos
+    ]
+
+
+@app.get("/students/{aluno_id}")
+def get_student(aluno_id: int):
+    aluno = controllers.obter_aluno(aluno_id)
+    if not aluno:
+        raise HTTPException(status_code=404, detail="Aluno not found")
+    (
+        _id,
+        nome,
+        email,
+        data_inicio,
+        plano,
+        pagamento,
+        progresso,
+        dieta,
+        treino,
+    ) = aluno
+    return {
+        "id": _id,
+        "nome": nome,
+        "email": email,
+        "data_inicio": data_inicio,
+        "plano": plano,
+        "pagamento": pagamento,
+        "progresso": progresso,
+        "dieta": dieta,
+        "treino": treino,
+    }
+
+
+@app.post("/students", status_code=201)
+def create_student(student: StudentIn):
+    aluno_id = controllers.adicionar_aluno(student.nome, student.email)
+    return {"id": aluno_id}
+
+
+@app.delete("/students/{aluno_id}", status_code=204)
+def delete_student(aluno_id: int):
+    if controllers.obter_aluno(aluno_id) is None:
+        raise HTTPException(status_code=404, detail="Aluno not found")
+    controllers.remover_aluno(aluno_id)
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient
+
+import ia_sarah.core.interfaces.api.server as server
+import ia_sarah.core.use_cases.controllers as controllers
+
+
+def test_api_crud(tmp_path):
+    controllers.db.DB_NAME = str(tmp_path / "test.db")
+    controllers.init_app()
+    client = TestClient(server.app)
+
+    # create
+    resp = client.post("/students", json={"nome": "Ana", "email": "ana@test.com"})
+    assert resp.status_code == 201
+    aluno_id = resp.json()["id"]
+
+    # list
+    resp = client.get("/students")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(a["id"] == aluno_id for a in data)
+
+    # get
+    resp = client.get(f"/students/{aluno_id}")
+    assert resp.status_code == 200
+    assert resp.json()["nome"] == "Ana"
+
+    # delete
+    resp = client.delete(f"/students/{aluno_id}")
+    assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- add FastAPI API server with CRUD endpoints
- expose `iasarah-api` console script
- update dependencies
- document how to run the API
- add API test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685797bbefc8832cb49dd14856aee5e8