### PR TITLE
Enable test extras for pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,16 @@ coverage = "^7.4"
 pytest-cov = "^4.1"
 httpx = "^0.27"
 
+[tool.poetry.extras]
+test = [
+    "pytest",
+    "pyvirtualdisplay",
+    "pytest-xdist",
+    "coverage",
+    "pytest-cov",
+    "httpx",
+]
+
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^7.3.0"


### PR DESCRIPTION
## Summary
- support optional test deps via Poetry extras

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a2fc1928832c85b76d9d0747f40e