### PR TITLE
Add run.py launcher for package execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,19 @@ O banco de dados é salvo em `~/.gestor_alunos/alunos.db`.
    python -m venv venv
    source venv/bin/activate  # Windows: venv\Scripts\activate
    ```
-4. Instale o programa:
+4. Para testar sem instalar o pacote, execute:
+   ```bash
+   python run.py
+   ```
+5. Instale o programa:
    ```bash
    pip install .
    ```
-5. Inicie a aplicação com:
+6. Inicie a aplicação com:
    ```bash
    iasarah
    ```
-6. Para rodar a API FastAPI:
+7. Para rodar a API FastAPI:
    ```bash
    iasarah-api
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
     build: .
     volumes:
       - .:/app
-    command: poetry run python -m main
+    command: poetry run python run.py
     environment:
       - SENTRY_DSN=

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -4,6 +4,10 @@ Quick Start
 Install dependencies and run the application::
 
     poetry install
+    python run.py
+
+Alternatively, after installing, you can use the console script::
+
     poetry run iasarah
 
 The interface lets you register students and training plans and export them in different formats.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+# Add src to sys.path to allow running without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+
+from ia_sarah.core.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add run.py so the app can be run without installation
- update docker-compose to use the launcher
- document how to run without installing in README and tutorial docs

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a4b94d30832c8acf735ae80fba87