### PR TITLE
Fix init_app reference in GUI

### DIFF
--- a/src/ia_sarah/core/interfaces/views/gui.py
+++ b/src/ia_sarah/core/interfaces/views/gui.py
@@ -14,6 +14,7 @@ from ...use_cases.controllers import (
     adicionar_aluno,
     atualizar_plano,
     gerar_treino_pdf,
+    init_app,
     listar_alunos,
     listar_planos,
     load_theme,


### PR DESCRIPTION
## Summary
- import `init_app` from controllers in GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685802ae522c832cb9049b7acf6ff773