### PR TITLE
Introduce PySide6 base interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ include = ["src/ia_sarah/core/config.json"]
 [tool.poetry.dependencies]
 python = "^3.11"
 ttkbootstrap = "^1.13"
+PySide6 = "^6.6"
 fpdf = "^1.7"
 pillow = "^10"
 openpyxl = "^3.1"

--- a/src/ia_sarah/core/interfaces/views/gui_qt.py
+++ b/src/ia_sarah/core/interfaces/views/gui_qt.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEasingCurve, QPropertyAnimation, Qt
+from PySide6.QtGui import QGuiApplication, QPixmap
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QPushButton,
+    QSplashScreen,
+    QStackedWidget,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ia_sarah.core.use_cases import controllers
+
+from .theme import Palette
+
+
+class MainWindow(QMainWindow):
+    """Base window using QStackedWidget for navigation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Sarah 4.0")
+        self.resize(900, 600)
+        self.stack = QStackedWidget()
+        self.setCentralWidget(self.stack)
+        self.pages: dict[str, QWidget] = {}
+        self._init_toolbar()
+        self._init_pages()
+
+    def _init_toolbar(self) -> None:
+        toolbar = QToolBar()
+        toolbar.setMovable(False)
+        self.addToolBar(toolbar)
+        btn_dashboard = QPushButton("Dashboard")
+        btn_dashboard.clicked.connect(lambda: self.show_page("dashboard"))
+        toolbar.addWidget(btn_dashboard)
+
+    def _init_pages(self) -> None:
+        dashboard = QWidget()
+        dashboard.setLayout(QVBoxLayout())
+        self.pages["dashboard"] = dashboard
+        self.stack.addWidget(dashboard)
+
+    def show_page(self, name: str) -> None:
+        widget = self.pages.get(name)
+        if widget:
+            self._animate_transition(widget)
+
+    def _animate_transition(self, widget: QWidget) -> None:
+        current = self.stack.currentWidget()
+        if current is widget:
+            return
+        self.stack.setCurrentWidget(widget)
+        if current:
+            anim_out = QPropertyAnimation(current, b"windowOpacity")
+            anim_out.setDuration(300)
+            anim_out.setStartValue(1.0)
+            anim_out.setEndValue(0.0)
+            anim_out.setEasingCurve(QEasingCurve.InOutQuad)
+            anim_out.start()
+        anim_in = QPropertyAnimation(widget, b"windowOpacity")
+        anim_in.setDuration(300)
+        anim_in.setStartValue(0.0)
+        anim_in.setEndValue(1.0)
+        anim_in.setEasingCurve(QEasingCurve.InOutQuad)
+        anim_in.start()
+
+
+def _show_splash(app: QApplication) -> None:
+    splash_pix = QPixmap(400, 300)
+    splash_pix.fill(Palette.dark_gray)
+    splash = QSplashScreen(splash_pix)
+    splash.setWindowFlag(Qt.WindowStaysOnTopHint)
+    splash.setWindowOpacity(0.0)
+    splash.show()
+    anim = QPropertyAnimation(splash, b"windowOpacity")
+    anim.setDuration(500)
+    anim.setStartValue(0.0)
+    anim.setEndValue(1.0)
+    anim.start()
+    QGuiApplication.processEvents()
+    app.processEvents()
+    anim.finished.connect(lambda: splash.close())
+
+
+def criar_interface() -> None:
+    """Launch the PySide6 interface."""
+
+    controllers.init_app()
+    app = QApplication([])
+    _show_splash(app)
+    window = MainWindow()
+    window.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    criar_interface()
+

--- a/src/ia_sarah/core/interfaces/views/theme.py
+++ b/src/ia_sarah/core/interfaces/views/theme.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from PySide6.QtGui import QColor
+
+
+class Palette:
+    """Central color palette for the PySide interface."""
+
+    electric_blue = QColor("#1e88e5")
+    vivid_orange = QColor("#ff9800")
+    dark_gray = QColor("#212121")
+    light_gray = QColor("#f5f5f5")
+    neon_green = QColor("#39ff14")
+

--- a/tests/test_gui_qt.py
+++ b/tests/test_gui_qt.py
@@ -1,0 +1,18 @@
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_import_qt_interface():
+    try:
+        gui_qt = import_module("ia_sarah.core.interfaces.views.gui_qt")
+    except Exception as exc:  # pragma: no cover - env issues
+        pytest.skip(f"PySide6 not available: {exc}")
+    assert hasattr(gui_qt, "criar_interface")
+
+
+


### PR DESCRIPTION
## Summary
- add `PySide6` dependency in project config
- provide central color palette in `theme.py`
- implement a minimal PySide6 GUI with a stacked widget and splash
- skip import test if PySide can't load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580df33118832c9845f6b64a78804a