### PR TITLE
Add Qt themed widgets and animations

### DIFF
--- a/src/ia_sarah/core/interfaces/views/__init__.py
+++ b/src/ia_sarah/core/interfaces/views/__init__.py
@@ -1,2 +1,3 @@
 from ia_sarah.core.interfaces.views.gui import *  # noqa: F401,F403
 from ia_sarah.core.interfaces.views.widgets import *  # noqa: F401,F403
+from ia_sarah.core.interfaces.views.widgets_qt import *  # noqa: F401,F403

--- a/src/ia_sarah/core/interfaces/views/gui_qt.py
+++ b/src/ia_sarah/core/interfaces/views/gui_qt.py
@@ -5,7 +5,6 @@ from PySide6.QtGui import QGuiApplication, QPixmap
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
-    QPushButton,
     QSplashScreen,
     QStackedWidget,
     QToolBar,
@@ -15,7 +14,8 @@ from PySide6.QtWidgets import (
 
 from ia_sarah.core.use_cases import controllers
 
-from .theme import Palette
+from .theme import Palette, stylesheet
+from .widgets_qt import AnimatedButton, CardFrame
 
 
 class MainWindow(QMainWindow):
@@ -35,13 +35,16 @@ class MainWindow(QMainWindow):
         toolbar = QToolBar()
         toolbar.setMovable(False)
         self.addToolBar(toolbar)
-        btn_dashboard = QPushButton("Dashboard")
+        btn_dashboard = AnimatedButton("Dashboard")
         btn_dashboard.clicked.connect(lambda: self.show_page("dashboard"))
         toolbar.addWidget(btn_dashboard)
 
     def _init_pages(self) -> None:
         dashboard = QWidget()
-        dashboard.setLayout(QVBoxLayout())
+        layout = QVBoxLayout()
+        card = CardFrame()
+        layout.addWidget(card)
+        dashboard.setLayout(layout)
         self.pages["dashboard"] = dashboard
         self.stack.addWidget(dashboard)
 
@@ -92,6 +95,7 @@ def criar_interface() -> None:
 
     controllers.init_app()
     app = QApplication([])
+    app.setStyleSheet(stylesheet())
     _show_splash(app)
     window = MainWindow()
     window.show()

--- a/src/ia_sarah/core/interfaces/views/theme.py
+++ b/src/ia_sarah/core/interfaces/views/theme.py
@@ -12,3 +12,23 @@ class Palette:
     light_gray = QColor("#f5f5f5")
     neon_green = QColor("#39ff14")
 
+
+def stylesheet() -> str:
+    """Return the default QSS stylesheet for the application."""
+
+    return f"""
+    QPushButton {{
+        background-color: {Palette.electric_blue.name()};
+        color: white;
+        border-radius: 4px;
+        padding: 4px 10px;
+    }}
+    QPushButton:hover {{
+        background-color: {Palette.vivid_orange.name()};
+    }}
+    QFrame#card {{
+        background-color: {Palette.light_gray.name()};
+        border-radius: 8px;
+    }}
+    """
+

--- a/src/ia_sarah/core/interfaces/views/widgets_qt.py
+++ b/src/ia_sarah/core/interfaces/views/widgets_qt.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEasingCurve, QPoint, QPropertyAnimation
+from PySide6.QtWidgets import (
+    QPushButton,
+    QFrame,
+    QGraphicsDropShadowEffect,
+)
+
+from .theme import Palette
+
+
+class AnimatedButton(QPushButton):
+    """QPushButton with simple hover and click animations."""
+
+    def __init__(self, text: str = "", parent=None) -> None:
+        super().__init__(text, parent)
+        self._hover_anim: QPropertyAnimation | None = None
+        self._click_anim: QPropertyAnimation | None = None
+        self._shadow = QGraphicsDropShadowEffect(self)
+        self._shadow.setBlurRadius(8)
+        self._shadow.setOffset(0, 2)
+        self._shadow.setColor(Palette.dark_gray)
+        self._shadow.setEnabled(False)
+        self.setGraphicsEffect(self._shadow)
+
+    def enterEvent(self, event) -> None:  # noqa: D401 - Qt signature
+        self._shadow.setEnabled(True)
+        self._animate_hover(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:  # noqa: D401 - Qt signature
+        self._animate_hover(False)
+        self._shadow.setEnabled(False)
+        super().leaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # noqa: D401 - Qt signature
+        self._animate_click()
+        super().mousePressEvent(event)
+
+    def _animate_hover(self, entering: bool) -> None:
+        start = self.pos()
+        delta = QPoint(0, -2) if entering else QPoint(0, 2)
+        end = start + delta
+        self._hover_anim = QPropertyAnimation(self, b"pos")
+        self._hover_anim.setDuration(150)
+        self._hover_anim.setStartValue(start)
+        self._hover_anim.setEndValue(end)
+        self._hover_anim.setEasingCurve(QEasingCurve.OutQuad)
+        self._hover_anim.start()
+
+    def _animate_click(self) -> None:
+        start = self.pos()
+        self._click_anim = QPropertyAnimation(self, b"pos")
+        self._click_anim.setDuration(200)
+        self._click_anim.setKeyValueAt(0.5, start + QPoint(0, 4))
+        self._click_anim.setEndValue(start)
+        self._click_anim.setEasingCurve(QEasingCurve.OutBounce)
+        self._click_anim.start()
+
+
+class CardFrame(QFrame):
+    """Container frame styled as a card with drop shadow."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("card")
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(15)
+        shadow.setOffset(0, 2)
+        shadow.setColor(Palette.dark_gray)
+        self.setGraphicsEffect(shadow)

--- a/tests/test_gui_qt.py
+++ b/tests/test_gui_qt.py
@@ -15,4 +15,10 @@ def test_import_qt_interface():
     assert hasattr(gui_qt, "criar_interface")
 
 
-
+def test_stylesheet_string():
+    try:
+        theme = import_module("ia_sarah.core.interfaces.views.theme")
+    except Exception as exc:  # pragma: no cover - env issues
+        pytest.skip(f"PySide6 not available: {exc}")
+    css = theme.stylesheet()
+    assert isinstance(css, str) and "QPushButton" in css


### PR DESCRIPTION
## Summary
- extend Qt theme with a stylesheet
- add AnimatedButton and CardFrame widgets
- integrate new widgets into the Qt interface
- add tests for stylesheet helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685813b6aa34832c81eeb3140995cbec