### PR TITLE
Refactor UI to PySide6 MegaPack 4.0

### DIFF
--- a/src/ia_sarah/core/interfaces/views/__init__.py
+++ b/src/ia_sarah/core/interfaces/views/__init__.py
@@ -1,3 +1,6 @@
 from ia_sarah.core.interfaces.views.gui import *  # noqa: F401,F403
 from ia_sarah.core.interfaces.views.widgets import *  # noqa: F401,F403
-from ia_sarah.core.interfaces.views.widgets_qt import *  # noqa: F401,F403
+try:  # pragma: no cover - optional PySide
+    from ia_sarah.core.interfaces.views.widgets_qt import *  # noqa: F401,F403
+except Exception:
+    pass

--- a/src/ia_sarah/core/interfaces/views/gui_qt.py
+++ b/src/ia_sarah/core/interfaces/views/gui_qt.py
@@ -28,6 +28,7 @@ class MainWindow(QMainWindow):
         self.stack = QStackedWidget()
         self.setCentralWidget(self.stack)
         self.pages: dict[str, QWidget] = {}
+        self.dark = False
         self._init_toolbar()
         self._init_pages()
 
@@ -38,15 +39,38 @@ class MainWindow(QMainWindow):
         btn_dashboard = AnimatedButton("Dashboard")
         btn_dashboard.clicked.connect(lambda: self.show_page("dashboard"))
         toolbar.addWidget(btn_dashboard)
+        btn_alunos = AnimatedButton("Alunos")
+        btn_alunos.clicked.connect(lambda: self.show_page("alunos"))
+        toolbar.addWidget(btn_alunos)
+        btn_config = AnimatedButton("Config")
+        btn_config.clicked.connect(lambda: self.show_page("config"))
+        toolbar.addWidget(btn_config)
+        theme_btn = AnimatedButton("\u263e")
+        theme_btn.clicked.connect(self.toggle_theme)
+        toolbar.addWidget(theme_btn)
+
+    def toggle_theme(self) -> None:
+        self.dark = not self.dark
+        self.setStyleSheet(stylesheet(self.dark))
 
     def _init_pages(self) -> None:
         dashboard = QWidget()
-        layout = QVBoxLayout()
-        card = CardFrame()
-        layout.addWidget(card)
-        dashboard.setLayout(layout)
+        dash_layout = QVBoxLayout(dashboard)
+        dash_layout.addWidget(CardFrame())
         self.pages["dashboard"] = dashboard
         self.stack.addWidget(dashboard)
+
+        alunos = QWidget()
+        alunos_layout = QVBoxLayout(alunos)
+        alunos_layout.addWidget(CardFrame())
+        self.pages["alunos"] = alunos
+        self.stack.addWidget(alunos)
+
+        config = QWidget()
+        config_layout = QVBoxLayout(config)
+        config_layout.addWidget(CardFrame())
+        self.pages["config"] = config
+        self.stack.addWidget(config)
 
     def show_page(self, name: str) -> None:
         widget = self.pages.get(name)
@@ -57,20 +81,33 @@ class MainWindow(QMainWindow):
         current = self.stack.currentWidget()
         if current is widget:
             return
-        self.stack.setCurrentWidget(widget)
         if current:
-            anim_out = QPropertyAnimation(current, b"windowOpacity")
-            anim_out.setDuration(300)
-            anim_out.setStartValue(1.0)
-            anim_out.setEndValue(0.0)
-            anim_out.setEasingCurve(QEasingCurve.InOutQuad)
-            anim_out.start()
-        anim_in = QPropertyAnimation(widget, b"windowOpacity")
-        anim_in.setDuration(300)
-        anim_in.setStartValue(0.0)
-        anim_in.setEndValue(1.0)
-        anim_in.setEasingCurve(QEasingCurve.InOutQuad)
-        anim_in.start()
+            out_anim = QPropertyAnimation(current, b"pos")
+            out_anim.setDuration(300)
+            out_anim.setStartValue(current.pos())
+            out_anim.setEndValue(current.pos() - QPoint(self.width(), 0))
+            out_anim.setEasingCurve(QEasingCurve.InOutQuad)
+            out_anim.start()
+            fade_out = QPropertyAnimation(current, b"windowOpacity")
+            fade_out.setDuration(300)
+            fade_out.setStartValue(1.0)
+            fade_out.setEndValue(0.0)
+            fade_out.setEasingCurve(QEasingCurve.InOutQuad)
+            fade_out.start()
+        self.stack.setCurrentWidget(widget)
+        widget.move(self.width(), 0)
+        in_anim = QPropertyAnimation(widget, b"pos")
+        in_anim.setDuration(300)
+        in_anim.setStartValue(widget.pos())
+        in_anim.setEndValue(QPoint(0, 0))
+        in_anim.setEasingCurve(QEasingCurve.InOutQuad)
+        in_anim.start()
+        fade_in = QPropertyAnimation(widget, b"windowOpacity")
+        fade_in.setDuration(300)
+        fade_in.setStartValue(0.0)
+        fade_in.setEndValue(1.0)
+        fade_in.setEasingCurve(QEasingCurve.InOutQuad)
+        fade_in.start()
 
 
 def _show_splash(app: QApplication) -> None:
@@ -80,14 +117,23 @@ def _show_splash(app: QApplication) -> None:
     splash.setWindowFlag(Qt.WindowStaysOnTopHint)
     splash.setWindowOpacity(0.0)
     splash.show()
-    anim = QPropertyAnimation(splash, b"windowOpacity")
-    anim.setDuration(500)
-    anim.setStartValue(0.0)
-    anim.setEndValue(1.0)
-    anim.start()
+    anim_in = QPropertyAnimation(splash, b"windowOpacity")
+    anim_in.setDuration(500)
+    anim_in.setStartValue(0.0)
+    anim_in.setEndValue(1.0)
+    anim_in.start()
     QGuiApplication.processEvents()
     app.processEvents()
-    anim.finished.connect(lambda: splash.close())
+
+    def finish() -> None:
+        anim_out = QPropertyAnimation(splash, b"windowOpacity")
+        anim_out.setDuration(500)
+        anim_out.setStartValue(1.0)
+        anim_out.setEndValue(0.0)
+        anim_out.finished.connect(splash.close)
+        anim_out.start()
+
+    anim_in.finished.connect(finish)
 
 
 def criar_interface() -> None:

--- a/src/ia_sarah/core/interfaces/views/theme.py
+++ b/src/ia_sarah/core/interfaces/views/theme.py
@@ -6,29 +6,43 @@ from PySide6.QtGui import QColor
 class Palette:
     """Central color palette for the PySide interface."""
 
-    electric_blue = QColor("#1e88e5")
-    vivid_orange = QColor("#ff9800")
+    # primary / secondary / neutral colours
+    electric_blue = QColor("#2979ff")
+    vivid_orange = QColor("#ff6d00")
     dark_gray = QColor("#212121")
-    light_gray = QColor("#f5f5f5")
+    white = QColor("#ffffff")
     neon_green = QColor("#39ff14")
 
 
-def stylesheet() -> str:
+def stylesheet(dark: bool = False) -> str:
     """Return the default QSS stylesheet for the application."""
 
+    bg = Palette.dark_gray.name() if dark else Palette.white.name()
+    fg = Palette.white.name() if dark else Palette.dark_gray.name()
+
     return f"""
+    * {{
+        font-family: 'Roboto', sans-serif;
+    }}
+    QMainWindow {{
+        background: {bg};
+        color: {fg};
+    }}
+    QToolBar {{
+        background: {Palette.dark_gray.name()};
+    }}
     QPushButton {{
         background-color: {Palette.electric_blue.name()};
-        color: white;
-        border-radius: 4px;
-        padding: 4px 10px;
+        color: {Palette.white.name()};
+        border-radius: 6px;
+        padding: 6px 12px;
     }}
     QPushButton:hover {{
         background-color: {Palette.vivid_orange.name()};
     }}
     QFrame#card {{
-        background-color: {Palette.light_gray.name()};
-        border-radius: 8px;
+        background-color: {Palette.white.name()};
+        border-radius: 10px;
     }}
     """
 

--- a/src/ia_sarah/core/main.py
+++ b/src/ia_sarah/core/main.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ia_sarah.core.interfaces.views.gui import criar_interface
+from ia_sarah.core.interfaces.views.gui_qt import criar_interface
 from ia_sarah.core.telemetry import init as init_telemetry
 
 


### PR DESCRIPTION
## Summary
- implement PySide6 UI as default
- add dark/light palette with modern colors
- animate buttons with geometry animations
- provide SPA-style navigation via QStackedWidget
- animated splash screen fade in/out
- guard optional Qt widgets in package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858150b99c4832caa06c901ef961a31