### PR TITLE
Implement dashboard stats

### DIFF
--- a/src/ia_sarah/core/adapters/repositories/db.py
+++ b/src/ia_sarah/core/adapters/repositories/db.py
@@ -204,3 +204,35 @@ def remover_plano(plano_id: int) -> None:
     except sqlite3.Error as exc:  # pragma: no cover - database errors
         logger.error("Erro ao remover plano: %s", exc)
         raise
+
+
+def contar_alunos() -> int:
+    """Return the total number of students."""
+    try:
+        with closing(sqlite3.connect(DB_NAME)) as conn:
+            cur = conn.execute("SELECT COUNT(*) FROM alunos")
+            (total,) = cur.fetchone()
+            return int(total)
+    except sqlite3.Error as exc:  # pragma: no cover - database errors
+        logger.error("Erro ao contar alunos: %s", exc)
+        raise
+
+
+def listar_planos_recentes(limit: int = 5) -> list[tuple]:
+    """Return the most recently created plans with student names."""
+    try:
+        with closing(sqlite3.connect(DB_NAME)) as conn:
+            cur = conn.execute(
+                """
+            SELECT planos.id, planos.nome, alunos.nome
+            FROM planos
+            JOIN alunos ON planos.aluno_id = alunos.id
+            ORDER BY planos.id DESC
+            LIMIT ?
+            """,
+                (limit,),
+            )
+            return cur.fetchall()
+    except sqlite3.Error as exc:  # pragma: no cover - database errors
+        logger.error("Erro ao listar planos recentes: %s", exc)
+        raise

--- a/src/ia_sarah/core/interfaces/views/gui_qt.py
+++ b/src/ia_sarah/core/interfaces/views/gui_qt.py
@@ -8,6 +8,8 @@ from PySide6.QtWidgets import (
     QApplication,
     QDialog,
     QDialogButtonBox,
+    QLabel,
+    QListWidget,
     QFileDialog,
     QFormLayout,
     QHBoxLayout,
@@ -80,6 +82,36 @@ class PlanDialog(QDialog):
             self.desc_edit.text(),
             self.ex_edit.text(),
         )
+
+
+class DashboardPage(QWidget):
+    """Simple dashboard with statistics."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        card_stats = CardFrame()
+        stats_layout = QVBoxLayout(card_stats)
+        self.total_label = QLabel()
+        stats_layout.addWidget(self.total_label)
+        layout.addWidget(card_stats)
+
+        card_recent = CardFrame()
+        recent_layout = QVBoxLayout(card_recent)
+        recent_layout.addWidget(QLabel("Planos recentes:"))
+        self.plans_list = QListWidget()
+        recent_layout.addWidget(self.plans_list)
+        layout.addWidget(card_recent)
+
+        self.load_data()
+
+    def load_data(self) -> None:
+        total = controllers.contar_alunos()
+        self.total_label.setText(f"Total de alunos: {total}")
+        self.plans_list.clear()
+        for _id, nome, aluno in controllers.listar_planos_recentes(5):
+            self.plans_list.addItem(f"{nome} - {aluno}")
 
 
 class AlunosPage(QWidget):
@@ -317,9 +349,7 @@ class MainWindow(QMainWindow):
         self.setStyleSheet(stylesheet(self.dark))
 
     def _init_pages(self) -> None:
-        dashboard = QWidget()
-        dash_layout = QVBoxLayout(dashboard)
-        dash_layout.addWidget(CardFrame())
+        dashboard = DashboardPage()
         self.pages["dashboard"] = dashboard
         self.stack.addWidget(dashboard)
 

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -88,6 +88,19 @@ def remover_plano(plano_id: int) -> None:
     db.remover_plano(plano_id)
 
 
+# ----- Dashboard stats -----
+
+
+def contar_alunos() -> int:
+    """Return total number of students."""
+    return db.contar_alunos()
+
+
+def listar_planos_recentes(limit: int = 5) -> list[tuple]:
+    """Return most recent plans with student names."""
+    return db.listar_planos_recentes(limit)
+
+
 # ----- Exportação -----
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -35,3 +35,16 @@ def test_planos_crud(tmp_path):
     db.remover_plano(plano_id)
     planos = db.listar_planos(aluno_id)
     assert planos == []
+
+
+def test_stats_functions(tmp_path):
+    db.DB_NAME = str(tmp_path / "test.db")
+    db.init_db()
+    # add students and plans
+    a1 = db.adicionar_aluno("Joana", "joana@test.com")
+    a2 = db.adicionar_aluno("Carlos", "carlos@test.com")
+    db.adicionar_plano(a1, "Plano 1", "desc", "[]")
+    db.adicionar_plano(a2, "Plano 2", "desc", "[]")
+    assert db.contar_alunos() == 2
+    recentes = db.listar_planos_recentes(1)
+    assert recentes and recentes[0][1] == "Plano 2"


### PR DESCRIPTION
## Summary
- add functions for counting students and listing recent plans
- expose new stats functions in controllers
- create a DashboardPage GUI showing total students and recent plans
- replace placeholder dashboard page
- test new DB stats functions

## Testing
- `pip install -r requirements.txt | tail -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858331d1de0832c9c289110ba6655eb