### PR TITLE
Add configuration API

### DIFF
--- a/src/ia_sarah/core/adapters/utils/config_manager.py
+++ b/src/ia_sarah/core/adapters/utils/config_manager.py
@@ -58,9 +58,15 @@ def load_theme() -> str:
     return config.get("theme", "superhero")
 
 
+def update_config(updates: Dict[str, Any]) -> None:
+    """Merge and persist configuration updates."""
+
+    config = load_config()
+    config.update(updates)
+    save_config(config)
+
+
 def save_theme(theme: str) -> None:
     """Persist the selected theme."""
 
-    config = load_config()
-    config["theme"] = theme
-    save_config(config)
+    update_config({"theme": theme})

--- a/src/ia_sarah/core/interfaces/api/server.py
+++ b/src/ia_sarah/core/interfaces/api/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+from typing import Any, Dict
 
 from ia_sarah.core.use_cases import controllers
 
@@ -11,6 +12,10 @@ app = FastAPI(title="I.A-Sarah API")
 class StudentIn(BaseModel):
     nome: str
     email: str
+
+
+class ThemeIn(BaseModel):
+    theme: str
 
 
 @app.on_event("startup")
@@ -66,6 +71,30 @@ def delete_student(aluno_id: int):
     if controllers.obter_aluno(aluno_id) is None:
         raise HTTPException(status_code=404, detail="Aluno not found")
     controllers.remover_aluno(aluno_id)
+
+
+@app.get("/theme")
+def get_theme():
+    """Return saved theme."""
+    return {"theme": controllers.load_theme()}
+
+
+@app.post("/theme", status_code=204)
+def set_theme(data: ThemeIn):
+    """Persist theme selection."""
+    controllers.save_theme(data.theme)
+
+
+@app.get("/config")
+def get_config() -> Dict[str, Any]:
+    """Return application configuration."""
+    return controllers.load_config()
+
+
+@app.post("/config", status_code=204)
+def update_config(config: Dict[str, Any]):
+    """Update and persist configuration values."""
+    controllers.update_config(config)
 
 
 def main() -> None:

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -11,6 +11,8 @@ from ia_sarah.core.adapters.services import pdf_utils
 from ia_sarah.core.adapters.services.exporters import get_exporter
 from ia_sarah.core.adapters.utils.config_manager import load_theme as _load_theme
 from ia_sarah.core.adapters.utils.config_manager import save_theme as _save_theme
+from ia_sarah.core.adapters.utils.config_manager import load_config as _load_config
+from ia_sarah.core.adapters.utils.config_manager import update_config as _update_config
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,16 @@ def load_theme() -> str:
 def save_theme(theme: str) -> None:
     """Persist theme selection."""
     _save_theme(theme)
+
+
+def load_config() -> dict:
+    """Return entire configuration."""
+    return _load_config()
+
+
+def update_config(data: dict) -> None:
+    """Merge and persist configuration data."""
+    _update_config(data)
 
 
 # ----- Alunos -----

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 import ia_sarah.core.interfaces.api.server as server
 import ia_sarah.core.use_cases.controllers as controllers
+import ia_sarah.core.adapters.utils.config_manager as cm
 
 
 def test_api_crud(tmp_path):
@@ -33,3 +34,26 @@ def test_api_crud(tmp_path):
     # delete
     resp = client.delete(f"/students/{aluno_id}")
     assert resp.status_code == 204
+
+
+def test_config_api(tmp_path):
+    controllers.db.DB_NAME = str(tmp_path / "test.db")
+    cm.CONFIG_FILE = tmp_path / "conf.json"
+    controllers.init_app()
+    client = TestClient(server.app)
+
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    assert resp.json() == {}
+
+    resp = client.post("/theme", json={"theme": "flat"})
+    assert resp.status_code == 204
+    assert cm.load_theme() == "flat"
+
+    resp = client.get("/theme")
+    assert resp.status_code == 200
+    assert resp.json()["theme"] == "flat"
+
+    resp = client.post("/config", json={"foo": "bar"})
+    assert resp.status_code == 204
+    assert cm.load_config()["foo"] == "bar"


### PR DESCRIPTION
## Summary
- provide `update_config` util to merge configuration data
- expose configuration helpers in `controllers`
- add `/theme` and `/config` endpoints on the API server
- test configuration REST endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858345732b0832ca54a87f94c78c0cd