### PR TITLE
Atualiza documentos e expõe lista de exportadores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@
 - Mantenha `requirements.txt` sincronizado com o `pyproject.toml`.
 - Atualize `README.md`, `LICENSE` e `guia_instalacao.txt` sempre que necessário.
 - Preserve o código limpo e livre de duplicações.
+- Documente no README cada nova função pública adicionada ao projeto.

--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -67,3 +67,8 @@
 - AGENTS.md atualizado com novas diretrizes.
 - Licença traduzida para português.
 - README atualizado.
+
+## Versão 2.7 - Catálogo de funções
+- Nova função `listar_exportadores` exposta em `controllers`.
+- README agora possui seção explicando como listar formatos de exportação.
+- AGENTS.md orienta documentar novas funções públicas.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Aplicação em Python para organizar alunos de academias ou atendimentos particu
 - Interface gráfica com tema claro/escuro
 - Plugins de exportação carregados dinamicamente
 
+### Plugins de exportação
+
+Os formatos disponíveis podem variar conforme plugins instalados. Para listar os
+formatos atuais diretamente no Python:
+
+```python
+from ia_sarah.core.use_cases import controllers
+print(controllers.listar_exportadores())
+```
+
+Por padrão estão incluídos os formatos `pdf`, `csv` e `xlsx`.
+
 ## Estrutura do Projeto
 ```
 src/

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -9,7 +9,7 @@ from typing import Iterable
 from ia_sarah.core.adapters.repositories import db
 from ia_sarah.core.entities.models import Student, TrainingPlan
 from ia_sarah.core.adapters.services import pdf_utils
-from ia_sarah.core.adapters.services.exporters import get_exporter
+from ia_sarah.core.adapters.services.exporters import get_exporter, _REGISTRY
 from ia_sarah.core.adapters.utils.config_manager import load_theme as _load_theme
 from ia_sarah.core.adapters.utils.config_manager import save_theme as _save_theme
 from ia_sarah.core.adapters.utils.config_manager import load_config as _load_config
@@ -253,6 +253,12 @@ def listar_planos_recentes(limit: int = 5) -> list[tuple]:
         Recent plan data.
     """
     return db.listar_planos_recentes(limit)
+
+
+def listar_exportadores() -> list[str]:
+    """Listar formatos de exportação disponíveis."""
+
+    return list(_REGISTRY.keys())
 
 
 # ----- Exportação -----

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from ia_sarah.core.use_cases import controllers
+
+
+def test_listar_exportadores():
+    formatos = controllers.listar_exportadores()
+    assert "pdf" in formatos
+    assert "csv" in formatos
+    assert "xlsx" in formatos


### PR DESCRIPTION
## Resumo
- README ganha seção explicando plugins de exportação
- AGENTS orienta documentar novas funções públicas
- Nova função `listar_exportadores` em `controllers`
- Teste cobrindo a nova função
- Patch notes registrados

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584d7288c0832cac858a00e724d7cd