### PR TITLE
Adiciona recarga de plugins

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -72,3 +72,7 @@
 - Nova função `listar_exportadores` exposta em `controllers`.
 - README agora possui seção explicando como listar formatos de exportação.
 - AGENTS.md orienta documentar novas funções públicas.
+
+## Versão 2.8 - Recarga de plugins
+- Função `reload_entrypoints` adicionada para atualizar plugins dinâmicos.
+- README demonstra como utilizá-la para recarregar exportadores.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ from ia_sarah.core.use_cases import controllers
 print(controllers.listar_exportadores())
 ```
 
+Se novos plugins forem instalados em tempo de execução, é possível atualizar
+a lista utilizando:
+
+```python
+from ia_sarah.core import plugin_loader
+plugin_loader.reload_entrypoints("ia_sarah.exporters")
+```
+
 Por padrão estão incluídos os formatos `pdf`, `csv` e `xlsx`.
 
 ## Estrutura do Projeto

--- a/src/ia_sarah/core/plugin_loader.py
+++ b/src/ia_sarah/core/plugin_loader.py
@@ -38,3 +38,10 @@ def load_entrypoints(group: str, callback: Callable[[str, Type], None]) -> None:
         _CACHE[group] = registry
     for name, obj in _CACHE[group].items():
         callback(name, obj)
+
+
+def reload_entrypoints(group: str) -> None:
+    """Reload plugins for ``group`` ignoring any cached values."""
+
+    _CACHE.pop(group, None)
+    load_entrypoints(group, lambda *_: None)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -31,3 +31,15 @@ def test_disable_plugin(monkeypatch):
     load_entrypoints("dummy", lambda n, o: registry.update({n: o}))
     assert registry == {}
     assert list_plugins("dummy") == []
+
+
+def test_reload_entrypoints(monkeypatch):
+    loader._CACHE = {}
+    eps1 = [type("ep", (), {"name": "dummy1", "load": lambda self: Dummy})()]
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps1)
+    assert list_plugins("dummy") == ["dummy1"]
+
+    eps2 = [type("ep", (), {"name": "dummy2", "load": lambda self: Dummy})()]
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps2)
+    loader.reload_entrypoints("dummy")
+    assert list_plugins("dummy") == ["dummy2"]


### PR DESCRIPTION
## Resumo
- nova função `reload_entrypoints` para atualizar plugins dinamicamente
- documentação atualizada com exemplo de uso
- testes cobrindo a recarga de plugins
- notas de versão incrementadas

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584fc678ac832ca41c587f2777394c