### PR TITLE
Implementa cadastro completo e backup

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -82,3 +82,8 @@
 - Configuração padrão gerada quando ausente e fallback de valores.
 - Banco de dados usa `data/db.sqlite` com migrações simples.
 - Interface Qt agora exibe erro se inicialização falhar.
+
+## Versão 3.0 - Cadastro completo e backup
+- Novo diálogo de aluno permite preencher plano e pagamento com validação.
+- Funções `adicionar_aluno_completo` e `backup_dados` expostas em `controllers`.
+- Página de configurações oferece seleção de tema, notificações e backup.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ plugin_loader.reload_entrypoints("ia_sarah.exporters")
 
 Por padrão estão incluídos os formatos `pdf`, `csv` e `xlsx`.
 
+### Cadastro completo e backup
+
+Para incluir um aluno com todos os campos disponíveis utilize:
+
+```python
+id = controllers.adicionar_aluno_completo(
+    "Daniel",
+    "daniel@email.com",
+    plano="Avancado",
+    pagamento="Cartao",
+)
+```
+
+O banco pode ser copiado para um arquivo local com:
+
+```python
+controllers.backup_dados("backup.sqlite")
+```
+
 ## Estrutura do Projeto
 ```
 src/

--- a/src/ia_sarah/core/adapters/utils/config_manager.py
+++ b/src/ia_sarah/core/adapters/utils/config_manager.py
@@ -17,7 +17,11 @@ CONFIG_FILE: Path = Path(
     )
 )
 
-DEFAULT_CONFIG: Dict[str, Any] = {"theme": "superhero", "metrics_port": 8000}
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "theme": "superhero",
+    "metrics_port": 8000,
+    "notifications": True,
+}
 
 
 def load_config() -> Dict[str, Any]:

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -122,6 +122,23 @@ def adicionar_aluno(nome: str, email: str) -> int:
     return db.adicionar_aluno(nome, email)
 
 
+def adicionar_aluno_completo(
+    nome: str,
+    email: str,
+    data_inicio: str | None = None,
+    plano: str | None = None,
+    pagamento: str | None = None,
+    progresso: str | None = None,
+    dieta: str | None = None,
+    treino: str | None = None,
+) -> int:
+    """Create a student filling all optional fields."""
+
+    return db.adicionar_aluno_completo(
+        nome, email, data_inicio, plano, pagamento, progresso, dieta, treino
+    )
+
+
 def atualizar_aluno(aluno_id: int, campo: str, valor: str) -> None:
     """Update a single field of a student.
 
@@ -253,6 +270,12 @@ def listar_planos_recentes(limit: int = 5) -> list[tuple]:
         Recent plan data.
     """
     return db.listar_planos_recentes(limit)
+
+
+def backup_dados(dest: str | Path) -> None:
+    """Create a copy of the database at ``dest``."""
+
+    db.backup_database(dest)
 
 
 def listar_exportadores() -> list[str]:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -11,6 +11,7 @@ def test_config_crud(tmp_path):
     cm.save_config({"theme": "flat"})
     data = cm.load_config()
     assert data["theme"] == "flat"
+    assert data["notifications"] is True
     cm.save_config({"theme": "dark"})
     assert cm.load_theme() == "dark"
     cm.delete_config()

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -11,3 +11,17 @@ def test_listar_exportadores():
     assert "pdf" in formatos
     assert "csv" in formatos
     assert "xlsx" in formatos
+
+
+def test_adicionar_completo_e_backup(tmp_path):
+    controllers.db.DB_NAME = str(tmp_path / "test.db")
+    controllers.init_app()
+    aluno_id = controllers.adicionar_aluno_completo("Eva", "eva@test.com", plano="Especial")
+    from ia_sarah.core.adapters.repositories import db
+
+    dados = db.obter_aluno(aluno_id)
+    assert dados and dados[4] == "Especial"
+
+    backup = tmp_path / "copy.sqlite"
+    controllers.backup_dados(backup)
+    assert backup.exists() and backup.stat().st_size > 0


### PR DESCRIPTION
## Resumo
- adiciona função `adicionar_aluno_completo` e backup do banco
- cria `FullStudentDialog` e `ConfigPage` na interface Qt
- novo campo `notifications` na configuração padrão
- inclui testes para cadastro completo, backup e config
- atualiza README e PATCH_NOTES

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685859716878832c911eb98ee7e119c1