### PR TITLE
Adiciona cadastro premium com PDF

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -90,3 +90,7 @@
 
 ## Versão 3.1 - Repaginação visual
 - Tema Qt modernizado com novos estilos para botões e tabelas.
+
+## Versão 3.2 - Cadastro premium
+- Função `adicionar_aluno_com_plano_pdf` cria aluno, plano e gera PDF.
+- Exemplo de uso adicionado na documentação.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ O banco pode ser copiado para um arquivo local com:
 controllers.backup_dados("backup.sqlite")
 ```
 
+### Cadastro com plano e PDF
+
+Para criar um aluno já associado a um plano e gerar o PDF automaticamente:
+
+```python
+aluno_id, plano_id = controllers.adicionar_aluno_com_plano_pdf(
+    "Maria",
+    "maria@email.com",
+    plano="Treino A",
+    descricao="Plano inicial",
+    exercicios_json="[]",
+    pdf_dest="treino.pdf",
+)
+```
+
 ## Estrutura do Projeto
 ```
 src/

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Iterable
+import json
 
 from ia_sarah.core.adapters.repositories import db
 from ia_sarah.core.entities.models import Student, TrainingPlan
@@ -210,6 +211,49 @@ def adicionar_plano(
         Generated identifier for the plan.
     """
     return db.adicionar_plano(aluno_id, nome, descricao, exercicios_json)
+
+
+def adicionar_aluno_com_plano_pdf(
+    nome: str,
+    email: str,
+    plano: str,
+    descricao: str,
+    exercicios_json: str,
+    pdf_dest: Path | str,
+) -> tuple[int, int]:
+    """Criar aluno, plano e gerar PDF de treino.
+
+    Parameters
+    ----------
+    nome:
+        Nome do aluno.
+    email:
+        Endereço de e-mail.
+    plano:
+        Nome do plano de treino.
+    descricao:
+        Descrição do plano.
+    exercicios_json:
+        Lista de exercícios em JSON.
+    pdf_dest:
+        Caminho de saída do PDF.
+
+    Returns
+    -------
+    tuple[int, int]
+        IDs do aluno e do plano criados.
+    """
+
+    aluno_id = adicionar_aluno(nome, email)
+    plano_id = adicionar_plano(aluno_id, plano, descricao, exercicios_json)
+    try:
+        exercicios = json.loads(exercicios_json or "[]")
+        if not isinstance(exercicios, list):
+            exercicios = []
+    except Exception:
+        exercicios = []
+    exportar_treino("pdf", plano, exercicios, pdf_dest)
+    return aluno_id, plano_id
 
 
 def atualizar_plano(

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -25,3 +25,19 @@ def test_adicionar_completo_e_backup(tmp_path):
     backup = tmp_path / "copy.sqlite"
     controllers.backup_dados(backup)
     assert backup.exists() and backup.stat().st_size > 0
+
+
+def test_adicionar_com_plano_pdf(tmp_path):
+    controllers.db.DB_NAME = str(tmp_path / "test.db")
+    controllers.init_app()
+    pdf_file = tmp_path / "treino.pdf"
+    aluno_id, plano_id = controllers.adicionar_aluno_com_plano_pdf(
+        "Leo",
+        "leo@test.com",
+        plano="Treino B",
+        descricao="desc",
+        exercicios_json="[]",
+        pdf_dest=pdf_file,
+    )
+    assert pdf_file.exists() and pdf_file.stat().st_size > 0
+    assert aluno_id > 0 and plano_id > 0


### PR DESCRIPTION
## Resumo
- permite cadastrar aluno e gerar plano em PDF no mesmo fluxo
- atualiza README com exemplo de uso
- registra nova versão no PATCH_NOTES
- cobre novo caso no teste de controllers

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585e0535f0832caf28be8c48baf83d