### PR TITLE
Adiciona suporte a CORS na API

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -100,3 +100,6 @@
 
 ## Versão 3.4 - Frontend web
 - Adicionada página `web/index.html` para testar a API.
+
+## Versão 3.5 - CORS na API
+- Middleware `CORSMiddleware` adicionado ao servidor FastAPI permitindo requisições de qualquer origem.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ O banco de dados é salvo em `~/.gestor_alunos/alunos.db`.
 * `METRICS_PORT` - porta utilizada pelo servidor de métricas.
 * `DISABLED_PLUGINS` - lista de plugins separados por vírgula a serem ignorados.
 
+### CORS na API
+As rotas da API agora permitem solicitações de qualquer origem (CORS habilitado).
+
 ### Testes
 Para executar os testes:
 ```bash

--- a/src/ia_sarah/core/interfaces/api/server.py
+++ b/src/ia_sarah/core/interfaces/api/server.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Any, Dict
 
 from ia_sarah.core.use_cases import controllers
 
 app = FastAPI(title="I.A-Sarah API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class StudentIn(BaseModel):


### PR DESCRIPTION
## Descrição
- aplica o middleware `CORSMiddleware` no servidor FastAPI
- documenta o suporte a CORS no README
- registra a mudança no PATCH_NOTES

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858697a32fc832cb7c38323d0b152bf