### PR TITLE
Pequena atualização de estatísticas

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -104,3 +104,8 @@
 ## Versão 3.5 - Orientação de testes
 - README atualizado com seção explicando como instalar dependências de teste usando `pip install -r requirements.txt`.
 
+## Versão 3.6 - Estatísticas da API
+- Novo endpoint `/stats` retorna total de alunos e planos recentes.
+- Função `obter_estatisticas` adicionada aos `controllers`.
+- Frontend web exibe estatísticas através do novo botão.
+

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ aluno_id, plano_id = controllers.adicionar_aluno_com_plano_pdf(
 )
 ```
 
+### Estatísticas da aplicação
+
+Para saber quantos alunos existem e quais são os planos mais recentes:
+
+```python
+print(controllers.obter_estatisticas())
+```
+
+A mesma informação está disponível na API pelo endpoint `/stats`.
+
 ## Estrutura do Projeto
 ```
 src/

--- a/src/ia_sarah/core/interfaces/api/server.py
+++ b/src/ia_sarah/core/interfaces/api/server.py
@@ -87,6 +87,12 @@ async def update_config(config: Dict[str, Any]):
     controllers.update_config(config)
 
 
+@app.get("/stats")
+async def get_stats(limit: int = 5):
+    """Return basic application statistics."""
+    return controllers.obter_estatisticas(limit)
+
+
 def main() -> None:
     import uvicorn
 

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Any
 import json
 
 from ia_sarah.core.adapters.repositories import db
@@ -320,6 +320,26 @@ def backup_dados(dest: str | Path) -> None:
     """Create a copy of the database at ``dest``."""
 
     db.backup_database(dest)
+
+
+def obter_estatisticas(limit: int = 5) -> dict[str, Any]:
+    """Retornar contagem de alunos e planos recentes.
+
+    Parameters
+    ----------
+    limit:
+        Quantidade máxima de planos recentes.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dicionário com ``total_alunos`` e ``planos_recentes``.
+    """
+
+    return {
+        "total_alunos": contar_alunos(),
+        "planos_recentes": listar_planos_recentes(limit),
+    }
 
 
 def listar_exportadores() -> list[str]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,3 +60,8 @@ async def test_config_api(tmp_path):
         resp = await client.post("/config", json={"foo": "bar"})
         assert resp.status_code == 204
         assert cm.load_config()["foo"] == "bar"
+
+        resp = await client.get("/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total_alunos" in data

--- a/web/index.html
+++ b/web/index.html
@@ -43,6 +43,12 @@
         <pre id="config-output"></pre>
     </section>
 
+    <section>
+        <h2>Estatísticas</h2>
+        <button id="load-stats">Carregar estatísticas</button>
+        <pre id="stats-output"></pre>
+    </section>
+
 <script>
 const API = 'http://localhost:8001';
 
@@ -115,6 +121,14 @@ document.getElementById('update-config-form').addEventListener('submit', async (
         alert('JSON inválido');
     }
 });
+
+async function loadStats() {
+    const res = await fetch(`${API}/stats`);
+    const data = await res.json();
+    document.getElementById('stats-output').textContent = JSON.stringify(data, null, 2);
+}
+
+document.getElementById('load-stats').addEventListener('click', loadStats);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Notas
- Novo endpoint `/stats` para consultar número de alunos e planos recentes
- Função `obter_estatisticas` documentada no README
- Testes e frontend adaptados

------
https://chatgpt.com/codex/tasks/task_e_68586d10af0c832c87044cd956f5dd11