### PR TITLE
Implementa modal para cadastro e edição de alunos

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -117,3 +117,8 @@
 - Diretório `.devcontainer/` permite abrir o projeto em contêiner no VS Code.
 - README detalha como utilizar a extensão **Dev Containers**.
 
+## Versão 3.9 - Modal de alunos
+- Formulário substituído por modal para cadastro e edição de alunos.
+- Endpoint PUT `/students/{id}` adicionado à API.
+- Página `web/index.html` atualizada com tabela e validação imediata.
+

--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ O banco de dados é salvo em `~/.gestor_alunos/alunos.db`.
   iasarah-cli listar
   ```
 8. Com a API em execução, abra o arquivo `web/index.html` em seu navegador
-   e utilize o formulário para interagir com os endpoints `/students`,
-   `/theme` e `/config`.
+   e utilize os botões para listar alunos. O cadastro e a edição são
+   realizados em um modal acessado por **Novo aluno** ou **Editar**,
+   interagindo com os endpoints `/students`, `/theme` e `/config`.
 
 ### Variáveis de ambiente importantes
 * `CONFIG_FILE` - caminho opcional para o arquivo de configuração.

--- a/src/ia_sarah/core/interfaces/api/server.py
+++ b/src/ia_sarah/core/interfaces/api/server.py
@@ -56,6 +56,15 @@ async def create_student(student: StudentIn):
     return {"id": aluno_id}
 
 
+@app.put("/students/{aluno_id}", status_code=204)
+async def update_student(aluno_id: int, student: StudentIn):
+    """Update an existing student."""
+    if controllers.obter_aluno(aluno_id) is None:
+        raise HTTPException(status_code=404, detail="Aluno not found")
+    controllers.atualizar_aluno(aluno_id, "nome", student.nome)
+    controllers.atualizar_aluno(aluno_id, "email", student.email)
+
+
 @app.delete("/students/{aluno_id}", status_code=204)
 async def delete_student(aluno_id: int):
     if controllers.obter_aluno(aluno_id) is None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,15 @@ async def test_api_crud(tmp_path):
         assert resp.status_code == 200
         assert resp.json()["nome"] == "Ana"
 
+        # update
+        resp = await client.put(
+            f"/students/{aluno_id}",
+            json={"nome": "Ana Maria", "email": "ana.maria@test.com"},
+        )
+        assert resp.status_code == 204
+        resp = await client.get(f"/students/{aluno_id}")
+        assert resp.json()["nome"] == "Ana Maria"
+
         # delete
         resp = await client.delete(f"/students/{aluno_id}")
         assert resp.status_code == 204

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,10 @@
         section { margin-bottom: 2rem; }
         input, button { padding: 0.4rem; margin-right: 0.5rem; }
         pre { background: #f0f0f0; padding: 1rem; }
+        table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+        th, td { border: 1px solid #ccc; padding: 0.4rem; text-align: left; }
+        dialog { border: none; padding: 1rem; border-radius: 4px; }
+        dialog::backdrop { background: rgba(0,0,0,0.3); }
     </style>
 </head>
 <body>
@@ -16,14 +20,20 @@
 
     <section>
         <h2>Alunos</h2>
-        <form id="create-student-form">
-            <input type="text" id="nome" placeholder="Nome" required>
-            <input type="email" id="email" placeholder="Email" required>
-            <button type="submit">Criar</button>
-        </form>
+        <button id="btn-new-student">Novo aluno</button>
         <button id="load-students">Listar alunos</button>
-        <pre id="students-output"></pre>
+        <table id="students-table"></table>
     </section>
+
+    <dialog id="student-modal">
+        <form id="student-form" method="dialog">
+            <input type="text" id="modal-nome" placeholder="Nome" required>
+            <input type="email" id="modal-email" placeholder="Email" required>
+            <input type="hidden" id="modal-id">
+            <button type="submit">Salvar</button>
+            <button type="button" id="modal-cancel">Cancelar</button>
+        </form>
+    </dialog>
 
     <section>
         <h2>Tema</h2>
@@ -52,25 +62,70 @@
 <script>
 const API = 'http://localhost:8001';
 
+const modal = document.getElementById('student-modal');
+const form = document.getElementById('student-form');
+const table = document.getElementById('students-table');
+
+function openModal(student = null) {
+    if (student) {
+        document.getElementById('modal-id').value = student.id;
+        document.getElementById('modal-nome').value = student.nome;
+        document.getElementById('modal-email').value = student.email;
+    } else {
+        form.reset();
+        document.getElementById('modal-id').value = '';
+    }
+    modal.showModal();
+}
+
 async function loadStudents() {
     const res = await fetch(`${API}/students`);
     const data = await res.json();
-    document.getElementById('students-output').textContent = JSON.stringify(data, null, 2);
+    renderTable(data);
 }
 
+function renderTable(data) {
+    table.innerHTML = '<tr><th>Nome</th><th>Email</th><th>Ações</th></tr>';
+    for (const aluno of data) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${aluno.nome}</td><td>${aluno.email}</td>`;
+        const actions = document.createElement('td');
+        const btnEdit = document.createElement('button');
+        btnEdit.textContent = 'Editar';
+        btnEdit.onclick = () => openModal(aluno);
+        actions.appendChild(btnEdit);
+        tr.appendChild(actions);
+        table.appendChild(tr);
+    }
+}
+
+document.getElementById('btn-new-student').addEventListener('click', () => openModal());
 document.getElementById('load-students').addEventListener('click', loadStudents);
 
-document.getElementById('create-student-form').addEventListener('submit', async (e) => {
+form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const nome = document.getElementById('nome').value;
-    const email = document.getElementById('email').value;
-    await fetch(`${API}/students`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nome, email })
-    });
+    const id = document.getElementById('modal-id').value;
+    const nome = document.getElementById('modal-nome').value;
+    const email = document.getElementById('modal-email').value;
+    const payload = { nome, email };
+    if (id) {
+        await fetch(`${API}/students/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+    } else {
+        await fetch(`${API}/students`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+    }
+    modal.close();
     loadStudents();
 });
+
+document.getElementById('modal-cancel').addEventListener('click', () => modal.close());
 
 async function loadTheme() {
     const res = await fetch(`${API}/theme`);


### PR DESCRIPTION
## Notas
- Adicionado endpoint PUT `/students/{id}` para edição de alunos.
- Novo modal no `web/index.html` permite cadastrar e editar registros com validação.
- Testes atualizados para cobrir a rota de edição.

## Checklist
- [x] Testes executados com sucesso (`pytest -q`).

------
https://chatgpt.com/codex/tasks/task_e_685870d64954832c9ff6c096d29e8fb4