### PR TITLE
Correções flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E402

--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -129,3 +129,7 @@
 - Seleção de tema claro/escuro via menu suspenso.
 - Tratamento de JSON inválido com modal de aviso.
 
+
+## Versão 4.1 - Conformidade flake8
+- Correções de estilo e criação do arquivo `.flake8`.
+

--- a/src/ia_sarah/core/adapters/repositories/db.py
+++ b/src/ia_sarah/core/adapters/repositories/db.py
@@ -87,7 +87,10 @@ def obter_aluno(aluno_id: int) -> Optional[tuple]:
     try:
         with sqlite3.connect(DB_NAME) as conn:
             cur = conn.execute(
-                "SELECT id, nome, email, data_inicio, plano, pagamento, progresso, dieta, treino FROM alunos WHERE id=?",
+                (
+                    "SELECT id, nome, email, data_inicio, plano, pagamento, "
+                    "progresso, dieta, treino FROM alunos WHERE id=?"
+                ),
                 (aluno_id,),
             )
             return cur.fetchone()
@@ -178,7 +181,8 @@ def listar_planos(aluno_id: int) -> list[tuple]:
     try:
         with sqlite3.connect(DB_NAME) as conn:
             cur = conn.execute(
-                "SELECT id, nome, descricao, exercicios FROM planos WHERE aluno_id=? ORDER BY id",
+                "SELECT id, nome, descricao, exercicios FROM planos "
+                "WHERE aluno_id=? ORDER BY id",
                 (aluno_id,),
             )
             return cur.fetchall()
@@ -194,7 +198,8 @@ def adicionar_plano(
     try:
         with sqlite3.connect(DB_NAME) as conn:
             cur = conn.execute(
-                "INSERT INTO planos (aluno_id, nome, descricao, exercicios) VALUES (?, ?, ?, ?)",
+                "INSERT INTO planos (aluno_id, nome, descricao, exercicios)"
+                " VALUES (?, ?, ?, ?)",
                 (aluno_id, nome, descricao, exercicios_json),
             )
             return cur.lastrowid

--- a/src/ia_sarah/core/adapters/services/exporters.py
+++ b/src/ia_sarah/core/adapters/services/exporters.py
@@ -35,7 +35,10 @@ class PDFExporter(Exporter):
         pdf.set_font("Arial", size=12)
         pdf.cell(200, 10, txt=title, ln=True, align="C")
         for ex in exercises:
-            line = f"{ex.get('nome','')} - {ex.get('series','')}x{ex.get('reps','')}"
+            line = (
+                f"{ex.get('nome', '')} - "
+                f"{ex.get('series', '')}x{ex.get('reps', '')}"
+            )
             if ex.get("peso"):
                 line += f" {ex['peso']}"
             if ex.get("descanso"):

--- a/src/ia_sarah/core/interfaces/views/gui_qt.py
+++ b/src/ia_sarah/core/interfaces/views/gui_qt.py
@@ -48,7 +48,12 @@ def show_feedback(parent: QWidget, message: str, error: bool = False) -> None:
 class StudentDialog(QDialog):
     """Simple dialog to edit student information."""
 
-    def __init__(self, nome: str = "", email: str = "", parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        nome: str = "",
+        email: str = "",
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Aluno")
         layout = QFormLayout(self)
@@ -363,7 +368,12 @@ class PlanosPage(QWidget):
         plano = self._get_plano(plano_id)
         if plano is None:
             return
-        dlg = PlanDialog(plano.nome, plano.descricao or "", plano.exercicios_json or "", self)
+        dlg = PlanDialog(
+            plano.nome,
+            plano.descricao or "",
+            plano.exercicios_json or "",
+            self,
+        )
         if dlg.exec() == QDialog.Accepted:
             nome, desc, ex = dlg.get_data()
             try:
@@ -406,7 +416,12 @@ class PlanosPage(QWidget):
         if not ok or not fmt:
             return
         default_name = controllers.sanitize_filename(plano.nome) + f".{fmt}"
-        path, _ = QFileDialog.getSaveFileName(self, "Exportar", default_name, f"*.{fmt}")
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Exportar",
+            default_name,
+            f"*.{fmt}",
+        )
         if not path:
             return
         try:
@@ -450,7 +465,12 @@ class ConfigPage(QWidget):
         controllers.update_config({"notifications": self.notify_box.isChecked()})
 
     def _backup(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Backup", "backup.sqlite", "*.sqlite")
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Backup",
+            "backup.sqlite",
+            "*.sqlite",
+        )
         if not path:
             return
         try:

--- a/src/ia_sarah/core/interfaces/views/theme.py
+++ b/src/ia_sarah/core/interfaces/views/theme.py
@@ -60,4 +60,3 @@ def stylesheet(dark: bool = False) -> str:
         border: none;
     }}
     """
-

--- a/src/ia_sarah/core/use_cases/controllers/__init__.py
+++ b/src/ia_sarah/core/use_cases/controllers/__init__.py
@@ -184,7 +184,13 @@ def listar_planos(aluno_id: int) -> list[TrainingPlan]:
     """
     records = db.listar_planos(aluno_id)
     return [
-        TrainingPlan(id=r[0], aluno_id=aluno_id, nome=r[1], descricao=r[2], exercicios_json=r[3])
+        TrainingPlan(
+            id=r[0],
+            aluno_id=aluno_id,
+            nome=r[1],
+            descricao=r[2],
+            exercicios_json=r[3],
+        )
         for r in records
     ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,8 @@ async def test_api_crud(tmp_path):
     transport = ASGITransport(app=server.app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         # create
-        resp = await client.post("/students", json={"nome": "Ana", "email": "ana@test.com"})
+        aluno = {"nome": "Ana", "email": "ana@test.com"}
+        resp = await client.post("/students", json=aluno)
         assert resp.status_code == 201
         aluno_id = resp.json()["id"]
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -16,7 +16,11 @@ def test_listar_exportadores():
 def test_adicionar_completo_e_backup(tmp_path):
     controllers.db.DB_NAME = str(tmp_path / "test.db")
     controllers.init_app()
-    aluno_id = controllers.adicionar_aluno_completo("Eva", "eva@test.com", plano="Especial")
+    aluno_id = controllers.adicionar_aluno_completo(
+        "Eva",
+        "eva@test.com",
+        plano="Especial",
+    )
     from ia_sarah.core.adapters.repositories import db
 
     dados = db.obter_aluno(aluno_id)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -16,7 +16,11 @@ def test_load_entrypoints(monkeypatch):
     eps = [
         type("ep", (), {"name": "dummy", "load": lambda self: Dummy})(),
     ]
-    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps)  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: eps,
+    )  # type: ignore[attr-defined]
     registry = {}
     load_entrypoints("dummy", lambda n, o: registry.update({n: o}))
     assert registry["dummy"] is Dummy
@@ -24,7 +28,11 @@ def test_load_entrypoints(monkeypatch):
 
 def test_disable_plugin(monkeypatch):
     eps = [type("ep", (), {"name": "dummy", "load": lambda self: Dummy})()]
-    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps)  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: eps,
+    )  # type: ignore[attr-defined]
     monkeypatch.setenv("DISABLED_PLUGINS", "dummy")
     loader._CACHE = {}
     registry = {}
@@ -36,10 +44,18 @@ def test_disable_plugin(monkeypatch):
 def test_reload_entrypoints(monkeypatch):
     loader._CACHE = {}
     eps1 = [type("ep", (), {"name": "dummy1", "load": lambda self: Dummy})()]
-    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps1)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: eps1,
+    )
     assert list_plugins("dummy") == ["dummy1"]
 
     eps2 = [type("ep", (), {"name": "dummy2", "load": lambda self: Dummy})()]
-    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps2)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: eps2,
+    )
     loader.reload_entrypoints("dummy")
     assert list_plugins("dummy") == ["dummy2"]


### PR DESCRIPTION
## Resumo
- criar arquivo `.flake8` para definir regras
- adequar código e testes às regras do flake8
- registrar notas de atualização

## Testes
- `pytest -q`
- `flake8 | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_68588320fee8832ca303b413ed5aee5a