### PR TITLE
Scripts para abrir projeto nas IDEs

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -153,3 +153,7 @@
 
 ## Versão 4.6 - Tela inicial repaginada
 - Layout escuro com sidebar e painéis inspirados em patch notes 0.6.6.
+
+## Versao 4.7 - Abertura facil em IDEs
+- Scripts `open_pycharm.py` e `open_vscode.py` permitem abrir o projeto diretamente no PyCharm ou VS Code.
+

--- a/README.md
+++ b/README.md
@@ -170,5 +170,8 @@ configuração em `.devcontainer/` utiliza o `Dockerfile` do projeto e instala a
 dependências automaticamente. Após a criação do contêiner, os comandos de
 tarefas e depuração funcionam normalmente.
 
+## Abertura rápida em IDEs
+Execute `open_pycharm.py` para abrir o projeto no PyCharm ou `open_vscode.py` para abrir no VS Code. Os comandos `pycharm` e `code` devem estar no PATH.
+
 ## Licença
 Distribuído sob a Licença MIT em português. Veja o arquivo [LICENSE](LICENSE).

--- a/open_pycharm.py
+++ b/open_pycharm.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Abre o projeto I.A-Sarah no PyCharm."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Tenta executar o comando ``pycharm`` apontando para a raiz."""
+    repo_root = Path(__file__).resolve().parent
+    try:
+        subprocess.run(["pycharm", str(repo_root)], check=True)
+    except FileNotFoundError:
+        sys.exit("PyCharm não encontrado. Adicione 'pycharm' ao PATH.")
+
+
+if __name__ == "__main__":
+    main()

--- a/open_vscode.py
+++ b/open_vscode.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Abre o projeto I.A-Sarah no Visual Studio Code."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Tenta executar o comando ``code`` apontando para a raiz."""
+    repo_root = Path(__file__).resolve().parent
+    try:
+        subprocess.run(["code", str(repo_root)], check=True)
+    except FileNotFoundError:
+        sys.exit("VS Code não encontrado. Adicione 'code' ao PATH.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Descrição
- adiciona `open_pycharm.py` e `open_vscode.py`
- documenta nova seção de abertura rápida no README
- registra a versão 4.7 no PATCH_NOTES

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589f9e6670832ca6d8332c46abcdd3