### PR TITLE
Abrir design web automaticamente

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -164,3 +164,6 @@
 - Estilo das tabelas atualizado para bordas suaves e espaçamento entre linhas,
   evitando aparência de planilha.
 
+## Versão 5.0 - Interface web automática
+- `iasarah-api` agora abre `web/index.html` no navegador ao iniciar.
+

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ O banco de dados é salvo em `~/.gestor_alunos/alunos.db`.
    ```bash
    iasarah
    ```
-6. Para rodar a API FastAPI:
+6. Para rodar a API FastAPI e abrir automaticamente a interface web:
  ```bash
   iasarah-api
   ```
@@ -125,8 +125,8 @@ O banco de dados é salvo em `~/.gestor_alunos/alunos.db`.
   ```bash
   iasarah-cli listar
   ```
-8. Com a API em execução, abra o arquivo `web/index.html` em seu navegador
-   e utilize os botões para listar ou excluir alunos. Todas as ações
+8. A página `web/index.html` será aberta em seu navegador padrão
+   e permite listar ou excluir alunos. Todas as ações
    exibem modais de confirmação e feedback. O tema claro/escuro pode
    ser escolhido em um menu suspenso, interagindo com os endpoints
    `/students`, `/theme` e `/config`. O layout utiliza o arquivo

--- a/src/ia_sarah/core/interfaces/api/server.py
+++ b/src/ia_sarah/core/interfaces/api/server.py
@@ -102,8 +102,24 @@ async def get_stats(limit: int = 5):
     return controllers.obter_estatisticas(limit)
 
 
-def main() -> None:
+def main(open_browser: bool = True) -> None:
+    """Inicializa o servidor e, opcionalmente, abre a interface web."""
     import uvicorn
+    import threading
+    import time
+    import webbrowser
+    from pathlib import Path
+
+    if open_browser:
+        root_dir = Path(__file__).resolve().parents[4]
+        index_file = root_dir / "web" / "index.html"
+
+        if index_file.is_file():
+            def _open() -> None:
+                time.sleep(1)
+                webbrowser.open_new_tab(index_file.as_uri())
+
+            threading.Thread(target=_open, daemon=True).start()
 
     uvicorn.run(app, host="0.0.0.0", port=8001)
 


### PR DESCRIPTION
## Resumo
- abrir automaticamente `web/index.html` ao iniciar o servidor API
- documentar a novidade no README
- registrar patch notes

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a5bf3664832ca45370a84530e881